### PR TITLE
Add external-dns and opencost helm charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ export KUBECONFIG=/tmp/hmc-aws-reg0-kubeconfig.yaml
 kubectl get svc -n ingress-nginx ingress-nginx-controller
 ```
 
-With your preffered DNS hosting, set your ingress domains to resolve to that IP/DNS name, that's how the traffic will flow to/from regional cluster. Eventually we plan to use K8s ExternalDNS to simplify this process.
+With your preffered DNS hosting, set your ingress domains to resolve to that IP/DNS name, that's how the traffic will flow to/from regional cluster. 
+To simplify this process it is posssible to enable [external-dns](https://kubernetes-sigs.github.io/external-dns/) helm chart deployment in values.
 
 Once your domain is resolvable your Grafana and vmauth should be accessible.
 

--- a/charts/motel-child/Chart.lock
+++ b/charts/motel-child/Chart.lock
@@ -14,5 +14,8 @@ dependencies:
 - name: fluent-bit
   repository: https://fluent.github.io/helm-charts
   version: 0.47.10
-digest: sha256:5d51e7e76aaa2891e2c1d115de6e9aa40abcd62bba9a286fdcdf7d2ad3bb2840
-generated: "2024-11-18T16:25:44.543741+01:00"
+- name: opencost
+  repository: https://opencost.github.io/opencost-helm-chart
+  version: 1.42.3
+digest: sha256:841e1f0434b1380f50d9e6f25f0ad29a7402e62a053b3fa52c466882e966974b
+generated: "2024-12-11T15:34:53.25708+02:00"

--- a/charts/motel-child/Chart.yaml
+++ b/charts/motel-child/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: motel-child
 description: A Helm chart that deploys Grafana, OpenTelemetry, and VictoriaMetrics.
-version: 0.1.1
+version: 0.1.2
 appVersion: "1.0"
 dependencies:
   - name: victoria-metrics-operator
@@ -24,3 +24,8 @@ dependencies:
     version: "0.47.*"
     repository: https://fluent.github.io/helm-charts
     condition: fluent-bit.enabled
+  - name: opencost
+    version: "1.42.*"
+    repository: https://opencost.github.io/opencost-helm-chart
+    condition: opencost.enabled
+

--- a/charts/motel-child/templates/victoria/vmagent.yaml
+++ b/charts/motel-child/templates/victoria/vmagent.yaml
@@ -25,4 +25,18 @@ spec:
         name: vmauth-creds
   scrapeInterval: 20s
   selectAllByDefault: true
+{{- if .Values.opencost.enabled | default false }}
+  inlineScrapeConfig: |
+    - job_name: opencost
+      honor_labels: true
+      scrape_interval: 1m
+      scrape_timeout: 10s
+      metrics_path: /metrics
+      scheme: http
+      dns_sd_configs:
+      - names:
+        - motel-child-opencost.motel-child
+        type: 'A'
+        port: 9003
+{{- end }}
 {{- end }}

--- a/charts/motel-child/values.yaml
+++ b/charts/motel-child/values.yaml
@@ -18,6 +18,22 @@ prometheus-node-exporter:
   extraArgs:
     - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
     - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
+opencost:
+  enabled: true
+  opencost:
+    prometheus:
+      username: "motel"
+      password: "motel"
+      external:
+        enabled: true
+        url: "https://vmauth.hmc0.example.net/vm/select/0/prometheus"
+      internal:
+        enabled: false
+    exporter:
+      defaultClusterId: "hmc-child"
+      extraEnv:
+        EMIT_KSM_V1_METRICS: "false"
+        EMIT_KSM_V1_METRICS_ONLY: "true"
 victoriametrics:
   enabled: true
   vmagent:

--- a/charts/motel-mothership/Chart.yaml
+++ b/charts/motel-mothership/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: motel-mothership
 description: A Helm chart that deploys Grafana, Promxy, and VictoriaMetrics.
-version: 0.1.5
+version: 0.1.6
 appVersion: "1.0"
 dependencies:
   - name: grafana-operator
@@ -12,3 +12,4 @@ dependencies:
     version: "0.36.*"
     repository: "https://victoriametrics.github.io/helm-charts/"
     condition: victoria-metrics-operator.enabled
+

--- a/charts/motel-mothership/files/dashboards/opencost-cost-reporter-basic-overview.yaml
+++ b/charts/motel-mothership/files/dashboards/opencost-cost-reporter-basic-overview.yaml
@@ -1,0 +1,1464 @@
+{{- $defaultDatasource := "prometheus" -}}
+__inputs:
+  - description: ''
+    label: Prometheus
+    name: DS_PROMETHEUS
+    pluginId: prometheus
+    pluginName: Prometheus
+    type: datasource
+__elements: {}
+__requires:
+  - type: grafana
+    id: grafana
+    name: Grafana
+    version: 10.4.2
+  - type: datasource
+    id: prometheus
+    name: Prometheus
+    version: 1.0.0
+  - type: panel
+    id: stat
+    name: Stat
+    version: ""
+  - type: panel
+    id: table
+    name: Table
+    version: ""
+  - type: panel
+    id: timeseries
+    name: Time series
+    version: ""
+annotations:
+  list:
+    - builtIn: 1
+      datasource:
+        type: grafana
+        uid: "-- Grafana --"
+      enable: true
+      hide: true
+      iconColor: rgba(0, 211, 255, 1)
+      name: Annotations & Alerts
+      type: dashboard
+editable: true
+fiscalYearStartMonth: 0
+graphTooltip: 0
+id:
+links: []
+liveNow: false
+panels:
+  - collapsed: false
+    gridPos:
+      h: 1
+      w: 24
+      x: 0
+      "y": 0
+    id: 2
+    panels: []
+    title: Cluster wide
+    type: row
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: ${datasource}
+    description: Based on the average node_total_hourly_cost in the last 30d
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        decimals: 2
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#299c46"
+              value:
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 6
+      w: 8
+      x: 0
+      "y": 1
+    id: 9
+    options:
+      colorMode: value
+      graphMode: area
+      justifyMode: auto
+      orientation: auto
+      reduceOptions:
+        calcs:
+          - lastNotNull
+        fields: ""
+        values: false
+      showPercentChange: false
+      textMode: auto
+      wideLayout: true
+    pluginVersion: 10.4.2
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: ${datasource}
+        editorMode: code
+        expr: sum(avg by (instance) (node_total_hourly_cost)) * 24
+        instant: false
+        interval: ""
+        legendFormat: __auto
+        range: true
+        refId: A
+    timeFrom: 30d
+    title: Average Daily Cloud Costs
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: ${datasource}
+    description: Based on total node price
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 20
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        mappings: []
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#299c46"
+              value:
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 6
+      w: 16
+      x: 8
+      "y": 1
+    id: 1
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: false
+      tooltip:
+        mode: single
+        sort: none
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr: sum(node_total_hourly_cost)
+        instant: false
+        legendFormat: Cluster Hour Cost
+        range: true
+        refId: A
+    title: Cluster Hour Cost
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: ${datasource}
+    description: Based on the average total hourly node cost from the last 30d
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        decimals: 2
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#299c46"
+              value:
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 6
+      w: 8
+      x: 0
+      "y": 7
+    id: 5
+    options:
+      colorMode: value
+      graphMode: area
+      justifyMode: auto
+      orientation: auto
+      reduceOptions:
+        calcs:
+          - lastNotNull
+        fields: ""
+        values: false
+      showPercentChange: false
+      textMode: auto
+      wideLayout: true
+    pluginVersion: 10.4.2
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr: sum(avg by (instance) (node_total_hourly_cost)) * 24 * 30
+        instant: false
+        interval: ""
+        legendFormat: __auto
+        range: true
+        refId: A
+    timeFrom: 30d
+    title: Estimative Monthly Cloud Costs
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: Based on total node price over 7d and 1d
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 0
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        mappings: []
+        max: 1
+        min: -1
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#299c46"
+              value:
+        unit: percentunit
+      overrides: []
+    gridPos:
+      h: 6
+      w: 8
+      x: 8
+      "y": 7
+    id: 10
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: true
+      tooltip:
+        mode: single
+        sort: none
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr: |-
+          1 - (
+            avg_over_time(
+              sum(node_total_hourly_cost) [1d:1h]
+            )
+          /
+            avg_over_time(
+              sum(node_total_hourly_cost) [7d:1h]
+            )
+          )
+        instant: false
+        legendFormat: Relative price now vs 7d ago (Hour Price)
+        range: true
+        refId: price_7d
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr: |-
+          1 - (
+            avg(sum(node_total_hourly_cost))
+          /
+            avg_over_time(
+              sum(node_total_hourly_cost) [1d:1h]
+            )
+          )
+        hide: false
+        instant: false
+        legendFormat: Relative price now vs 1d ago (Hour Price)
+        range: true
+        refId: price_1d
+    timeFrom: 7d
+    title: Relative price now vs (7/1)d ago (Hour Price)
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: Based on total node price over 7d and 1d
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 0
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        mappings: []
+        max: 1
+        min: -1
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#299c46"
+              value:
+        unit: percentunit
+      overrides: []
+    gridPos:
+      h: 6
+      w: 8
+      x: 16
+      "y": 7
+    id: 11
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: true
+      tooltip:
+        mode: single
+        sort: none
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          stdvar_over_time( sum(node_total_hourly_cost) by (instance_type) [7d:1d]
+          )
+        instant: false
+        legendFormat: Relative price now vs 7d ago (Hour Price)
+        range: true
+        refId: price_variation
+    timeFrom: 7d
+    title: Standard Variation of Cost by InstanceType (7d/1d)
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: ""
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        custom:
+          align: auto
+          cellOptions:
+            type: auto
+          inspect: false
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#73BF69"
+              value:
+        unit: currencyUSD
+      overrides:
+        - matcher:
+            id: byName
+            options: Value
+          properties:
+            - id: custom.cellOptions
+              value:
+                mode: gradient
+                type: gauge
+                valueDisplayMode: text
+    gridPos:
+      h: 22
+      w: 8
+      x: 0
+      "y": 13
+    id: 6
+    options:
+      cellHeight: sm
+      footer:
+        countRows: false
+        fields: ""
+        reducer:
+          - sum
+        show: false
+      showHeader: true
+      sortBy:
+        - desc: true
+          displayName: Cost
+    pluginVersion: 10.4.2
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "topk(20,\n  sum(\n    sum(container_memory_allocation_bytes) \n    by (namespace,instance)\n
+          \   * on(instance) group_left() (\n\t\t\tnode_ram_hourly_cost{} / 1024 / 1024
+          / 1024 * 720\n\t\t\t+ on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n\n    +\n\n    sum(container_cpu_allocation) \n    by (namespace,instance)\n
+          \   * on(instance) group_left() (\n\t\t\tnode_cpu_hourly_cost{} * 720\n\t\t\t+
+          on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n  ) by (namespace)\n)"
+        format: table
+        hide: false
+        instant: true
+        legendFormat: __auto
+        range: false
+        refId: top_namespaces
+    timeFrom: 30d
+    title: Estimated Top 20 Namespaces
+    transformations:
+      - id: organize
+        options:
+          excludeByName:
+            Time: true
+          includeByName: {}
+          indexByName: {}
+          renameByName:
+            Value: Cost
+            namespace: Namespace
+    type: table
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        custom:
+          align: auto
+          cellOptions:
+            type: auto
+          inspect: false
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#73BF69"
+              value:
+        unit: currencyUSD
+      overrides:
+        - matcher:
+            id: byName
+            options: Value
+          properties:
+            - id: custom.cellOptions
+              value:
+                mode: gradient
+                type: gauge
+                valueDisplayMode: text
+    gridPos:
+      h: 22
+      w: 8
+      x: 8
+      "y": 13
+    id: 8
+    options:
+      cellHeight: sm
+      footer:
+        countRows: false
+        fields: ""
+        reducer:
+          - sum
+        show: false
+      showHeader: true
+      sortBy: []
+    pluginVersion: 10.4.2
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "topk(20,\n  sum(\n    sum(container_memory_allocation_bytes) by (namespace,instance,
+          container)\n    * on(instance) group_left() (\n\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024 * 720\n\t\t\t+ on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n    +\n    sum(container_cpu_allocation) by (namespace,instance,
+          container)\n    * on(instance) group_left() (\n\t\t\tnode_cpu_hourly_cost{}
+          * 720\n\t\t\t+ on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n  ) by (namespace, container)\n)"
+        format: table
+        instant: true
+        legendFormat: __auto
+        range: false
+        refId: top_namespaces
+    timeFrom: 30d
+    title: Estimated Top 20 Containers
+    transformations:
+      - id: organize
+        options:
+          excludeByName:
+            Time: true
+          includeByName: {}
+          indexByName:
+            Time: 0
+            Value: 3
+            container: 2
+            namespace: 1
+          renameByName:
+            Value: Cost
+            container: Container
+            namespace: Namespace
+    type: table
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        custom:
+          align: auto
+          cellOptions:
+            type: auto
+          inspect: false
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#73BF69"
+              value:
+        unit: currencyUSD
+      overrides:
+        - matcher:
+            id: byName
+            options: Value
+          properties:
+            - id: custom.cellOptions
+              value:
+                mode: gradient
+                type: gauge
+                valueDisplayMode: text
+    gridPos:
+      h: 22
+      w: 8
+      x: 16
+      "y": 13
+    id: 7
+    options:
+      cellHeight: sm
+      footer:
+        countRows: false
+        fields: ""
+        reducer:
+          - sum
+        show: false
+      showHeader: true
+    pluginVersion: 10.4.2
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "topk(20,\n  sum(\n    sum(container_memory_allocation_bytes) by (namespace,instance,
+          pod)\n    * on(instance) group_left() (\n\t\t\tnode_ram_hourly_cost{} / 1024
+          / 1024 / 1024 * 720\n\t\t\t+ on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n    +\n    sum(container_cpu_allocation) by (namespace,instance,
+          pod)\n    * on(instance) group_left() (\n\t\t\tnode_cpu_hourly_cost{} * 720\n\t\t\t+
+          on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n  ) by (pod)\n)"
+        format: table
+        instant: true
+        legendFormat: __auto
+        range: false
+        refId: top_namespaces
+    timeFrom: 30d
+    title: Estimated Top 20 Pods
+    transformations:
+      - id: organize
+        options:
+          excludeByName:
+            Time: true
+          includeByName: {}
+          indexByName: {}
+          renameByName:
+            Value: Costs
+            namespace: Namespace
+            pod: Pod
+    type: table
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: ""
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        mappings: []
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 12
+      w: 24
+      x: 0
+      "y": 35
+    id: 3
+    options:
+      legend:
+        calcs:
+          - min
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: desc
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "sum(sum(container_memory_allocation_bytes) by (namespace,instance) * on(instance)
+          group_left() (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024 / 1024\n\t\t\t\t+
+          on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation) by (namespace,instance)
+          * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{} + on(node,instance_type)
+          group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t  \t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t
+          \ \t\t\t) * 0\n\t\t  \t)) by (namespace)"
+        instant: false
+        legendFormat: "{{`{{namespace}}`}}"
+        range: true
+        refId: A
+    title: Hour Cost by Namespace
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: ""
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        mappings: []
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 12
+      w: 24
+      x: 0
+      "y": 47
+    id: 4
+    options:
+      legend:
+        calcs:
+          - min
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+        sortBy: Name
+        sortDesc: false
+      tooltip:
+        mode: multi
+        sort: desc
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "sum(sum(container_memory_allocation_bytes) by (container,namespace, instance)
+          * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024
+          / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation) by (container,namespace,
+          instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{} +
+          on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (namespace, container)"
+        instant: false
+        legendFormat: "{{`{{namespace}}`}} / {{`{{container}}`}}"
+        range: true
+        refId: A
+    title: Hour Cost by Container
+    type: timeseries
+  - collapsed: false
+    gridPos:
+      h: 1
+      w: 24
+      x: 0
+      "y": 59
+    id: 12
+    panels: []
+    title: By Namespace $namespace
+    type: row
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        custom:
+          align: auto
+          cellOptions:
+            type: auto
+          inspect: false
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#73BF69"
+              value:
+        unit: currencyUSD
+      overrides:
+        - matcher:
+            id: byName
+            options: Value
+          properties:
+            - id: custom.cellOptions
+              value:
+                mode: gradient
+                type: gauge
+                valueDisplayMode: text
+    gridPos:
+      h: 21
+      w: 5
+      x: 0
+      "y": 60
+    id: 13
+    options:
+      cellHeight: sm
+      footer:
+        countRows: false
+        fields: ""
+        reducer:
+          - sum
+        show: false
+      showHeader: true
+      sortBy: []
+    pluginVersion: 10.4.2
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "topk(20,\n  sum(\n    sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (instance, container)\n    * on(instance) group_left() (\n\t\t\tnode_ram_hourly_cost
+          / 1024 / 1024 / 1024 * 720\n\t\t\t+ on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n    +\n    sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (instance, container)\n    * on(instance) group_left() (\n\t\t\tnode_cpu_hourly_cost{}
+          * 720\n\t\t\t+ on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n  ) by (container)\n)"
+        format: table
+        instant: true
+        legendFormat: __auto
+        range: false
+        refId: top_namespaces
+    timeFrom: 30d
+    title: Estimated Top 20 Containers
+    transformations:
+      - id: organize
+        options:
+          excludeByName:
+            Time: true
+          includeByName: {}
+          indexByName:
+            Time: 0
+            Value: 3
+            container: 2
+            namespace: 1
+          renameByName:
+            Value: Cost
+            container: Container
+            namespace: Namespace
+    type: table
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: Based on current usage
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: text
+              value:
+      overrides: []
+    gridPos:
+      h: 7
+      w: 4
+      x: 5
+      "y": 60
+    id: 14
+    options:
+      colorMode: value
+      graphMode: area
+      justifyMode: auto
+      orientation: auto
+      reduceOptions:
+        calcs:
+          - lastNotNull
+        fields: ""
+        values: false
+      showPercentChange: false
+      textMode: auto
+      wideLayout: true
+    pluginVersion: 10.4.2
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "sum(\n  sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_ram_hourly_cost / 1024
+          / 1024 / 1024\n    + on(node,instance_type) group_left()\n    label_replace\n
+          \   (\n      kube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n    ) * 0\n  )\n  +\n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_cpu_hourly_cost{}\n
+          \   + on(node,instance_type) group_left()\n    label_replace\n    (\n      kube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n
+          \   ) * 0\n  ) \n) * 720"
+        instant: true
+        legendFormat: __auto
+        range: false
+        refId: A
+    title: Estimated monthly costs
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: Based on current usage
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 20
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: text
+              value:
+      overrides: []
+    gridPos:
+      h: 7
+      w: 15
+      x: 9
+      "y": 60
+    id: 17
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: false
+      tooltip:
+        mode: single
+        sort: none
+    pluginVersion: 10.3.3
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "sum(\n  sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_ram_hourly_cost / 1024
+          / 1024 / 1024\n    + on(node,instance_type) group_left()\n    label_replace\n
+          \   (\n      kube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n    ) * 0\n  )\n  +\n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_cpu_hourly_cost{}\n
+          \   + on(node,instance_type) group_left()\n    label_replace\n    (\n      kube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n
+          \   ) * 0\n  ) \n) * 720"
+        instant: false
+        legendFormat: Costs
+        range: true
+        refId: A
+    title: Estimated monthly costs
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: Based on current usage
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: text
+              value:
+      overrides: []
+    gridPos:
+      h: 7
+      w: 4
+      x: 5
+      "y": 67
+    id: 15
+    options:
+      colorMode: value
+      graphMode: area
+      justifyMode: auto
+      orientation: auto
+      reduceOptions:
+        calcs:
+          - lastNotNull
+        fields: ""
+        values: false
+      showPercentChange: false
+      textMode: auto
+      wideLayout: true
+    pluginVersion: 10.4.2
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "sum(\n  sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_ram_hourly_cost / 1024
+          / 1024 / 1024\n    + on(node,instance_type) group_left()\n    label_replace\n
+          \   (\n      kube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n    ) * 0\n  )\n  +\n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_cpu_hourly_cost{}\n
+          \   + on(node,instance_type) group_left()\n    label_replace\n    (\n      kube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n
+          \   ) * 0\n  ) \n) * 24"
+        instant: true
+        legendFormat: __auto
+        range: false
+        refId: A
+    title: Estimated Daily Costs
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: Based on current usage
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 20
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: text
+              value:
+      overrides: []
+    gridPos:
+      h: 7
+      w: 15
+      x: 9
+      "y": 67
+    id: 19
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: false
+      tooltip:
+        mode: single
+        sort: none
+    pluginVersion: 10.3.3
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "sum(\n  sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_ram_hourly_cost / 1024
+          / 1024 / 1024\n    + on(node,instance_type) group_left()\n    label_replace\n
+          \   (\n      kube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n    ) * 0\n  )\n  +\n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_cpu_hourly_cost{}\n
+          \   + on(node,instance_type) group_left()\n    label_replace\n    (\n      kube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n
+          \   ) * 0\n  ) \n) * 24"
+        instant: false
+        legendFormat: Costs
+        range: true
+        refId: A
+    title: Estimated Daily Costs
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: Based on current usage
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: text
+              value:
+      overrides: []
+    gridPos:
+      h: 7
+      w: 4
+      x: 5
+      "y": 74
+    id: 16
+    options:
+      colorMode: value
+      graphMode: area
+      justifyMode: auto
+      orientation: auto
+      reduceOptions:
+        calcs:
+          - lastNotNull
+        fields: ""
+        values: false
+      showPercentChange: false
+      textMode: auto
+      wideLayout: true
+    pluginVersion: 10.4.2
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "sum(\n  sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_ram_hourly_cost / 1024
+          / 1024 / 1024\n    + on(node,instance_type) group_left()\n    label_replace\n
+          \   (\n      kube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n    ) * 0\n  )\n  +\n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_cpu_hourly_cost{}\n
+          \   + on(node,instance_type) group_left()\n    label_replace\n    (\n      kube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n
+          \   ) * 0\n  ) \n)"
+        instant: true
+        legendFormat: __auto
+        range: false
+        refId: A
+    title: Estimated Hourly Costs
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: Based on current usage
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 20
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: text
+              value:
+      overrides: []
+    gridPos:
+      h: 7
+      w: 15
+      x: 9
+      "y": 74
+    id: 18
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: false
+      tooltip:
+        mode: single
+        sort: none
+    pluginVersion: 10.3.3
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "sum(\n  sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_ram_hourly_cost / 1024
+          / 1024 / 1024\n    + on(node,instance_type) group_left()\n    label_replace\n
+          \   (\n      kube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n    ) * 0\n  )\n  +\n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_cpu_hourly_cost{}\n
+          \   + on(node,instance_type) group_left()\n    label_replace\n    (\n      kube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n
+          \   ) * 0\n  ) \n)"
+        instant: false
+        legendFormat: Costs
+        range: true
+        refId: A
+    title: Estimated Hourly Costs
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: ""
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        mappings: []
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 12
+      w: 24
+      x: 0
+      "y": 81
+    id: 20
+    options:
+      legend:
+        calcs:
+          - min
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: desc
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "topk(20,\n  sum(\n    sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (instance, container)\n    * on(instance) group_left() (\n\t\t\tnode_ram_hourly_cost
+          / 1024 / 1024 / 1024 * 720\n\t\t\t+ on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n    +\n    sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (instance, container)\n    * on(instance) group_left() (\n\t\t\tnode_cpu_hourly_cost{}
+          * 720\n\t\t\t+ on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n  ) by (container)\n)"
+        instant: false
+        legendFormat: "{{`{{namespace}}`}}"
+        range: true
+        refId: A
+    title: Hour Price by Namespace
+    type: timeseries
+refresh: ""
+schemaVersion: 39
+tags: []
+templating:
+  list:
+    - current:
+        selected: false
+        text: default
+        value: default
+      hide: 0
+      includeAll: false
+      label: Datasource
+      multi: false
+      name: datasource
+      options: []
+      query: prometheus
+      queryValue: ""
+      refresh: 1
+      regex: ""
+      skipUrlSync: false
+      type: datasource
+    - current: {}
+      datasource:
+        type: {{ $defaultDatasource }}
+        uid: "${datasource}"
+      definition: label_values(kube_namespace_labels,namespace)
+      hide: 0
+      includeAll: false
+      label: Namespace
+      multi: false
+      name: namespace
+      options: []
+      query:
+        qryType: 1
+        query: label_values(kube_namespace_labels,namespace)
+        refId: PrometheusVariableQueryEditor-VariableQuery
+      refresh: 2
+      regex: ""
+      skipUrlSync: false
+      sort: 1
+      type: query
+time:
+  from: now-1h
+  to: now
+timepicker: {}
+timezone: ""
+title: OpenCost / Cost reporter / Basic overview
+uid: opencost-cost-reporter-basic-overview
+version: 52
+weekStart: ""

--- a/charts/motel-mothership/files/dashboards/opencost-cost-reporter-detailed-overview.yaml
+++ b/charts/motel-mothership/files/dashboards/opencost-cost-reporter-detailed-overview.yaml
@@ -1,0 +1,2160 @@
+{{- $defaultDatasource := "prometheus" -}}
+__inputs:
+  - description: ""
+    label: Prometheus
+    name: DS_PROMETHEUS
+    pluginId: prometheus
+    pluginName: Prometheus
+    type: datasource
+__elements: {}
+__requires:
+  - type: grafana
+    id: grafana
+    name: Grafana
+    version: 9.3.4
+  - type: panel
+    id: graph
+    name: Graph (old)
+    version: ""
+  - type: datasource
+    id: prometheus
+    name: Prometheus
+    version: 1.0.0
+  - type: panel
+    id: stat
+    name: Stat
+    version: ""
+  - type: panel
+    id: table
+    name: Table
+    version: ""
+  - type: panel
+    id: timeseries
+    name: Time series
+    version: ""
+annotations:
+  list:
+    - builtIn: 1
+      datasource:
+        type: datasource
+        uid: grafana
+      enable: true
+      hide: true
+      iconColor: rgba(0, 211, 255, 1)
+      name: Annotations & Alerts
+      target:
+        limit: 100
+        matchAny: false
+        tags: []
+        type: dashboard
+      type: dashboard
+description: ""
+editable: true
+fiscalYearStartMonth: 0
+gnetId: 11270
+graphTooltip: 0
+id:
+links: []
+liveNow: false
+panels:
+  - collapsed: false
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    gridPos:
+      h: 1
+      w: 24
+      x: 0
+      "y": 0
+    id: 9
+    panels: []
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        refId: A
+    title: Cluster Wide
+    type: row
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        decimals: 2
+        mappings:
+          - options:
+              match: "null"
+              result:
+                text: N/A
+            type: special
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#299c46"
+              value:
+            - color: rgba(237, 129, 40, 0.89)
+              value: 1000
+            - color: "#d44a3a"
+              value: 1200
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 7
+      w: 6
+      x: 0
+      "y": 1
+    id: 5
+    links: []
+    maxDataPoints: 100
+    options:
+      colorMode: value
+      graphMode: area
+      justifyMode: auto
+      orientation: horizontal
+      reduceOptions:
+        calcs:
+          - lastNotNull
+        fields: ""
+        values: false
+      textMode: auto
+    pluginVersion: 9.3.4
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        expr: sum(node_total_hourly_cost * 24)
+        hide: false
+        instant: false
+        interval: ""
+        legendFormat: ""
+        refId: A
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        expr: |-
+          avg_over_time(
+            sum(node_total_hourly_cost) [30d:1d]
+          )
+        hide: true
+        interval: ""
+        legendFormat: ""
+        refId: B
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        expr: |-
+          1 - (
+            avg_over_time(
+              sum(node_total_hourly_cost) [1d:1h]
+            )
+          /
+            avg_over_time(
+              sum(node_total_hourly_cost) [7d:1h]
+            )
+          )
+        hide: true
+        interval: ""
+        legendFormat: ""
+        refId: C
+    title: AVG Cluster Cost (last 3 days) DAILY
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 20
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          lineInterpolation: linear
+          lineWidth: 4
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 7
+      w: 18
+      x: 6
+      "y": 1
+    id: 20
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: desc
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        expr: sum(node_total_hourly_cost)
+        hide: false
+        instant: false
+        interval: ""
+        legendFormat: Cluster Hour Cost
+        refId: A
+    timeFrom: 12h
+    title: Cluster Hour Price (last 12h)
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        decimals: 2
+        mappings:
+          - options:
+              match: "null"
+              result:
+                text: N/A
+            type: special
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#299c46"
+              value:
+            - color: rgba(237, 129, 40, 0.89)
+              value: 27000
+            - color: "#d44a3a"
+              value: 29000
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 8
+      w: 6
+      x: 0
+      "y": 8
+    id: 17
+    links: []
+    maxDataPoints: 100
+    options:
+      colorMode: value
+      graphMode: area
+      justifyMode: auto
+      orientation: horizontal
+      reduceOptions:
+        calcs:
+          - last
+        fields: ""
+        values: false
+      textMode: auto
+    pluginVersion: 9.3.4
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        expr: sum(node_total_hourly_cost * 720)
+        hide: false
+        instant: true
+        interval: ""
+        legendFormat: ""
+        refId: A
+    timeFrom: 720h
+    title: Estimative Cluster Cost (last 30 days based)
+    type: stat
+  - aliasColors: {}
+    bars: false
+    dashLength: 10
+    dashes: false
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fill: 0
+    fillGradient: 0
+    gridPos:
+      h: 8
+      w: 9
+      x: 6
+      "y": 8
+    hiddenSeries: false
+    id: 35
+    legend:
+      avg: false
+      current: false
+      max: false
+      min: false
+      show: true
+      total: false
+      values: false
+    lines: true
+    linewidth: 3
+    nullPointMode: "null"
+    options:
+      alertThreshold: true
+    percentage: false
+    pluginVersion: 9.3.4
+    pointradius: 2
+    points: false
+    renderer: flot
+    seriesOverrides: []
+    spaceLength: 10
+    stack: false
+    steppedLine: false
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        expr: |-
+          1 - (
+            avg_over_time(
+              sum(node_total_hourly_cost) [1d:1h]
+            )
+          /
+            avg_over_time(
+              sum(node_total_hourly_cost) [7d:1h]
+            )
+          )
+        interval: 1h
+        legendFormat: Relative price now vs 7d ago (Hour Price)
+        refId: A
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        expr: |-
+          1 - (
+            avg(sum(node_total_hourly_cost))
+          /
+            avg_over_time(
+              sum(node_total_hourly_cost) [1d:1h]
+            )
+          )
+        hide: false
+        interval: 1h
+        legendFormat: Relative price now vs 1d ago (Hour Price)
+        refId: B
+    thresholds: []
+    timeFrom: 7d
+    timeRegions: []
+    title: Relative price now vs (7/1)d ago (Hour Price)
+    tooltip:
+      shared: true
+      sort: 2
+      value_type: individual
+    type: graph
+    xaxis:
+      mode: time
+      show: true
+      values: []
+    yaxes:
+      - "$$hashKey": object:276
+        format: percentunit
+        logBase: 1
+        max: "1"
+        min: "-1"
+        show: true
+      - "$$hashKey": object:277
+        format: short
+        logBase: 1
+        show: false
+    yaxis:
+      align: false
+  - aliasColors: {}
+    bars: false
+    dashLength: 10
+    dashes: false
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fill: 0
+    fillGradient: 0
+    gridPos:
+      h: 8
+      w: 9
+      x: 15
+      "y": 8
+    hiddenSeries: false
+    id: 38
+    legend:
+      avg: false
+      current: false
+      max: false
+      min: false
+      show: true
+      total: false
+      values: false
+    lines: true
+    linewidth: 3
+    nullPointMode: "null"
+    options:
+      alertThreshold: true
+    percentage: false
+    pluginVersion: 9.3.4
+    pointradius: 2
+    points: false
+    renderer: flot
+    seriesOverrides: []
+    spaceLength: 10
+    stack: false
+    steppedLine: false
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        expr:
+          stdvar_over_time( sum(node_total_hourly_cost) by (instance_type) [7d:1d]
+          ) > 0
+        instant: false
+        interval: 1h
+        legendFormat: "{{ `{{instance_type }}` }}"
+        refId: A
+    thresholds: []
+    timeFrom: 7d
+    timeRegions: []
+    title: Standard Variation of Cost by InstanceType (7d/1d)
+    tooltip:
+      shared: true
+      sort: 2
+      value_type: individual
+    type: graph
+    xaxis:
+      mode: time
+      show: true
+      values: []
+    yaxes:
+      - "$$hashKey": object:103
+        format: currencyUSD
+        logBase: 1
+        show: true
+      - "$$hashKey": object:104
+        format: short
+        logBase: 1
+        show: false
+    yaxis:
+      align: false
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        custom:
+          align: auto
+          displayMode: auto
+          inspect: false
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides:
+        - matcher:
+            id: byName
+            options: Time
+          properties:
+            - id: custom.hidden
+              value: true
+        - matcher:
+            id: byName
+            options: namespace
+          properties:
+            - id: custom.width
+              value: 135
+        - matcher:
+            id: byName
+            options: Value
+          properties:
+            - id: custom.align
+              value: left
+    gridPos:
+      h: 23
+      w: 3
+      x: 0
+      "y": 16
+    id: 6
+    options:
+      footer:
+        fields: ""
+        reducer:
+          - sum
+        show: false
+      showHeader: true
+      sortBy:
+        - desc: true
+          displayName: Value
+    pluginVersion: 9.3.4
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "topk( 20, \n  sum(sum(container_memory_allocation_bytes) by (namespace,instance)
+          * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024
+          / 1024 * 730\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation) by (namespace,instance)
+          * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{} + on(node,instance_type)
+          group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t  \t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t
+          \ \t\t\t) * 0\n\t\t  \t) * 730) by (namespace)\n)"
+        format: table
+        instant: true
+        interval: ""
+        legendFormat: "{{`{{namespace}}`}}"
+        refId: A
+    title: Top 20 by Namespace
+    transformations: []
+    type: table
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        custom:
+          align: auto
+          displayMode: auto
+          inspect: false
+        decimals: 2
+        displayName: ""
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+            - color: red
+              value: 80
+        unit: short
+      overrides:
+        - matcher:
+            id: byName
+            options: Time
+          properties:
+            - id: displayName
+              value: Time
+            - id: custom.align
+            - id: custom.hidden
+              value: true
+        - matcher:
+            id: byName
+            options: Metric
+          properties:
+            - id: displayName
+              value: Container Name
+            - id: unit
+              value: short
+            - id: decimals
+              value: 2
+            - id: custom.align
+        - matcher:
+            id: byName
+            options: Value
+          properties:
+            - id: displayName
+              value: "Price "
+            - id: unit
+              value: currencyUSD
+            - id: decimals
+              value: 2
+            - id: custom.align
+        - matcher:
+            id: byName
+            options: Container Name
+          properties:
+            - id: custom.width
+              value: 124
+    gridPos:
+      h: 23
+      w: 4
+      x: 3
+      "y": 16
+    id: 2
+    options:
+      footer:
+        fields: ""
+        reducer:
+          - sum
+        show: false
+      showHeader: true
+      sortBy: []
+    pluginVersion: 9.3.4
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "topk( 20, \n  sum(sum(container_memory_allocation_bytes) by (container,instance)
+          * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024
+          / 1024 * 730\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation) by (container,instance)
+          * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{} + on(node,instance_type)
+          group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t  \t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t
+          \ \t\t\t) * 0\n\t\t  \t)) by (container)\n)"
+        instant: true
+        interval: ""
+        legendFormat: "{{`{{container}}`}}"
+        refId: A
+    title: Estimated Top 20 by Container (30 days)
+    transformations:
+      - id: seriesToRows
+        options:
+          reducers: []
+    type: table
+  - aliasColors: {}
+    bars: false
+    dashLength: 10
+    dashes: false
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        links: []
+      overrides: []
+    fill: 1
+    fillGradient: 0
+    gridPos:
+      h: 11
+      w: 17
+      x: 7
+      "y": 16
+    hiddenSeries: false
+    id: 15
+    legend:
+      avg: false
+      current: false
+      max: false
+      min: false
+      show: true
+      total: false
+      values: false
+    lines: true
+    linewidth: 1
+    nullPointMode: "null"
+    options:
+      alertThreshold: true
+    percentage: false
+    pluginVersion: 9.3.4
+    pointradius: 2
+    points: false
+    renderer: flot
+    seriesOverrides: []
+    spaceLength: 10
+    stack: false
+    steppedLine: false
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        expr:
+          "sum(sum(container_memory_allocation_bytes) by (namespace,instance) * on(instance)
+          group_left() (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024 / 1024\n\t\t\t\t+
+          on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation) by (namespace,instance)
+          * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{} + on(node,instance_type)
+          group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t  \t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t
+          \ \t\t\t) * 0\n\t\t  \t)) by (namespace)"
+        interval: ""
+        legendFormat: "{{`{{namespace}}`}}"
+        refId: A
+    thresholds: []
+    timeRegions: []
+    title: Hour Cost
+    tooltip:
+      shared: true
+      sort: 2
+      value_type: individual
+    type: graph
+    xaxis:
+      mode: time
+      show: true
+      values: []
+    yaxes:
+      - format: currencyUSD
+        logBase: 1
+        show: true
+      - format: short
+        logBase: 1
+        show: true
+    yaxis:
+      align: false
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: continuous-GrYlRd
+        custom:
+          axisCenteredZero: false
+          axisColorMode: series
+          axisGridShow: true
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 12
+      w: 17
+      x: 7
+      "y": 27
+    id: 16
+    options:
+      legend:
+        calcs:
+          - mean
+        displayMode: table
+        placement: right
+        showLegend: true
+        sortBy: Mean
+        sortDesc: true
+      timezone:
+        - browser
+      tooltip:
+        mode: multi
+        sort: desc
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "sum(sum(container_memory_allocation_bytes) by (container,namespace, instance)
+          * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024
+          / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation) by (container,namespace,
+          instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{} +
+          on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (namespace, container)"
+        interval: ""
+        legendFormat: "{{`{{namespace}}`}} / {{`{{container}}`}}"
+        range: true
+        refId: A
+    title: Hour Price by Container
+    type: timeseries
+  - collapsed: false
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    gridPos:
+      h: 1
+      w: 24
+      x: 0
+      "y": 39
+    id: 11
+    panels: []
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        refId: A
+    title: By Namespace $namespace
+    type: row
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        custom:
+          align: auto
+          displayMode: auto
+          inspect: false
+        decimals: 2
+        displayName: ""
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+            - color: red
+              value: 80
+        unit: short
+      overrides:
+        - matcher:
+            id: byName
+            options: Time
+          properties:
+            - id: displayName
+              value: Time
+            - id: custom.align
+            - id: custom.hidden
+              value: true
+        - matcher:
+            id: byName
+            options: Metric
+          properties:
+            - id: displayName
+              value: Container Name
+            - id: unit
+              value: short
+            - id: decimals
+              value: 2
+            - id: custom.align
+        - matcher:
+            id: byName
+            options: Value
+          properties:
+            - id: displayName
+              value: "Price "
+            - id: unit
+              value: currencyUSD
+            - id: decimals
+              value: 2
+            - id: custom.align
+              value: left
+    gridPos:
+      h: 21
+      w: 4
+      x: 0
+      "y": 40
+    id: 12
+    options:
+      footer:
+        fields: ""
+        reducer:
+          - sum
+        show: false
+      showHeader: true
+    pluginVersion: 9.3.4
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "topk( 20, \n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (container, instance, namespace) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (container, instance, namespace) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (container)\n)"
+        format: time_series
+        instant: true
+        interval: ""
+        legendFormat: "{{`{{container}}`}}"
+        refId: A
+    title: Top 20 by Container
+    transformations:
+      - id: seriesToRows
+        options:
+          reducers: []
+    type: table
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          fixedColor: rgb(31, 120, 193)
+          mode: fixed
+        decimals: 3
+        mappings:
+          - options:
+              match: "null"
+              result:
+                text: N/A
+            type: special
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 7
+      w: 4
+      x: 4
+      "y": 40
+    id: 23
+    interval: ""
+    links: []
+    maxDataPoints: 100
+    options:
+      colorMode: none
+      graphMode: area
+      justifyMode: auto
+      orientation: horizontal
+      reduceOptions:
+        calcs:
+          - mean
+        fields: "/^Month estimative$/"
+        values: false
+      textMode: auto
+    pluginVersion: 9.3.4
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "\n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) * 720"
+        instant: true
+        interval: ""
+        legendFormat: Month estimative
+        refId: A
+    title: Live Month Price
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        decimals: 3
+        links: []
+        mappings: []
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 7
+      w: 16
+      x: 8
+      "y": 40
+    id: 24
+    links: []
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: none
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "\n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) * 720"
+        instant: false
+        interval: ""
+        legendFormat: Month estimative
+        refId: A
+    title: Month Estimative avg
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          fixedColor: rgb(31, 120, 193)
+          mode: fixed
+        decimals: 3
+        mappings:
+          - options:
+              match: "null"
+              result:
+                text: N/A
+            type: special
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 7
+      w: 4
+      x: 4
+      "y": 47
+    id: 22
+    interval: ""
+    links: []
+    maxDataPoints: 100
+    options:
+      colorMode: none
+      graphMode: area
+      justifyMode: auto
+      orientation: horizontal
+      reduceOptions:
+        calcs:
+          - mean
+        fields: ""
+        values: false
+      textMode: auto
+    pluginVersion: 9.3.4
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "\n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) * 24 * 7"
+        instant: true
+        interval: ""
+        legendFormat: ""
+        refId: A
+    timeFrom: 72h
+    title: Live Day Price
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 7
+      w: 16
+      x: 8
+      "y": 47
+    id: 36
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: desc
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "topk( 20, \n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (namespace,container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (namespace,container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (namespace)\n)"
+        interval: ""
+        legendFormat: "{{`{{namespace}}`}}"
+        range: true
+        refId: A
+    title: Namespace Hour Price
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          fixedColor: rgb(31, 120, 193)
+          mode: fixed
+        decimals: 3
+        mappings:
+          - options:
+              match: "null"
+              result:
+                text: N/A
+            type: special
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 7
+      w: 4
+      x: 4
+      "y": 54
+    id: 25
+    interval: ""
+    links: []
+    maxDataPoints: 100
+    options:
+      colorMode: none
+      graphMode: area
+      justifyMode: auto
+      orientation: horizontal
+      reduceOptions:
+        calcs:
+          - mean
+        fields: ""
+        values: false
+      textMode: auto
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "\n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t))"
+        instant: true
+        interval: ""
+        legendFormat: ""
+        refId: A
+    timeFrom: 72h
+    title: Live Hour Price
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        max: 1
+        min: -1
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+            - color: red
+              value: 80
+        unit: percentunit
+      overrides:
+        - matcher:
+            id: byName
+            options: Relative price now vs 14d ago (Hour Price)
+          properties:
+            - id: color
+              value:
+                fixedColor: purple
+                mode: fixed
+        - matcher:
+            id: byName
+            options: Relative price now vs 7d ago (Hour Price)
+          properties:
+            - id: color
+              value:
+                fixedColor: blue
+                mode: fixed
+    gridPos:
+      h: 7
+      w: 16
+      x: 8
+      "y": 54
+    id: 14
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: desc
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "1 - (\n\navg_over_time(\n\n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (namespace, container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (namespace,container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (namespace) [1d:1h]\n            )\n
+          \           \n            /\n            \navg_over_time(\n\n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (namespace,container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (namespace,container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (namespace) [7d:1h]\n            )\n
+          \           )"
+        interval: ""
+        legendFormat: Relative price now vs 7d ago (Hour Price)
+        range: true
+        refId: A
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "1 - (\n\navg_over_time(\n\n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (namespace,container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (namespace,container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (namespace) [1d:1h]\n            )\n
+          \           \n            /\n            \navg_over_time(\n\n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (namespace,container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (namespace,container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (namespace) [14d:1h]\n            )\n
+          \           )"
+        interval: ""
+        legendFormat: Relative price now vs 14d ago (Hour Price)
+        range: true
+        refId: B
+    title: Relative price now vs (7/14)d ago (Hour Price)
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 11
+      w: 24
+      x: 0
+      "y": 61
+    id: 4
+    options:
+      legend:
+        calcs:
+          - mean
+          - max
+          - min
+        displayMode: table
+        placement: right
+        showLegend: true
+        sortBy: Mean
+        sortDesc: true
+      tooltip:
+        mode: multi
+        sort: desc
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "topk( 30, \n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (container)\n)"
+        interval: ""
+        legendFormat: "{{`{{container}}`}}"
+        range: true
+        refId: A
+    title: Hour Price by App
+    type: timeseries
+  - collapsed: false
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    gridPos:
+      h: 1
+      w: 24
+      x: 0
+      "y": 72
+    id: 19
+    panels: []
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        refId: A
+    title: App $app by pod
+    type: row
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          fixedColor: rgb(31, 120, 193)
+          mode: fixed
+        decimals: 3
+        mappings:
+          - options:
+              match: "null"
+              result:
+                text: N/A
+            type: special
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 6
+      w: 6
+      x: 0
+      "y": 73
+    id: 26
+    interval: ""
+    links: []
+    maxDataPoints: 100
+    options:
+      colorMode: none
+      graphMode: area
+      justifyMode: auto
+      orientation: horizontal
+      reduceOptions:
+        calcs:
+          - mean
+        fields: ""
+        values: false
+      textMode: auto
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "\n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\",
+          container=~\"$app.*\"}) by (container,instance) * on(instance) group_left()
+          (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type)
+          group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\",
+          container=~\"$app.*\"}) by (container,instance) * on(instance) group_left()
+          (\n\t  \t\t\tnode_cpu_hourly_cost{} + on(node,instance_type) group_left()\n\t\t
+          \ \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t  \t\t\t\tkube_node_labels{}, \"instance_type\",
+          \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t  \t\t\t)
+          * 0\n\t\t  \t))"
+        instant: true
+        interval: ""
+        legendFormat: ""
+        refId: A
+    timeFrom: 72h
+    title: Live Hour Price
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 6
+      w: 18
+      x: 6
+      "y": 73
+    id: 29
+    interval: ""
+    options:
+      legend:
+        calcs:
+          - mean
+          - lastNotNull
+          - max
+          - min
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: desc
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "sum(sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\",
+          container=~\"$app.*\"}) by (namespace,instance,container) * on(instance) group_left()
+          (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type)
+          group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t) + sum(container_cpu_allocation{namespace=~\"$namespace\", container=~\"$app.*\"})
+          by (namespace,instance,container) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (container))"
+        interval: ""
+        legendFormat: Hour Cost
+        range: true
+        refId: A
+    title: APP  Hour Price
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          fixedColor: rgb(31, 120, 193)
+          mode: fixed
+        decimals: 3
+        mappings:
+          - options:
+              match: "null"
+              result:
+                text: N/A
+            type: special
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 6
+      w: 6
+      x: 0
+      "y": 79
+    id: 27
+    interval: ""
+    links: []
+    maxDataPoints: 100
+    options:
+      colorMode: none
+      graphMode: area
+      justifyMode: auto
+      orientation: horizontal
+      reduceOptions:
+        calcs:
+          - mean
+        fields: ""
+        values: false
+      textMode: auto
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "\n  (sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\",
+          container=~\"$app.*\"}) by (container,instance) * on(instance) group_left()
+          (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type)
+          group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\",
+          container=~\"$app.*\"}) by (container,instance) * on(instance) group_left()
+          (\n\t  \t\t\tnode_cpu_hourly_cost{} + on(node,instance_type) group_left()\n\t\t
+          \ \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t  \t\t\t\tkube_node_labels{}, \"instance_type\",
+          \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t  \t\t\t)
+          * 0\n\t\t  \t))) * 24"
+        instant: true
+        interval: ""
+        legendFormat: ""
+        refId: A
+    timeFrom: 72h
+    title: Live Hour Price
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        max: 1
+        min: -1
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+            - color: red
+              value: 80
+        unit: percentunit
+      overrides:
+        - matcher:
+            id: byName
+            options: Relative price now vs 7d ago (Hour Price)
+          properties:
+            - id: color
+              value:
+                fixedColor: blue
+                mode: fixed
+    gridPos:
+      h: 6
+      w: 18
+      x: 6
+      "y": 79
+    id: 37
+    interval: ""
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: desc
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "1 - (\n\navg_over_time(\nsum(sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\",
+          container=~\"$app.*\"}) by (namespace,instance,container) * on(instance) group_left()
+          (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type)
+          group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t) + sum(container_cpu_allocation{namespace=~\"$namespace\", container=~\"$app.*\"})
+          by (namespace,instance,container) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (container)) [1d:1h]\n\t\t\t\t\t)\n/\n\navg_over_time(\nsum(sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\",
+          container=~\"$app.*\"}) by (namespace,instance,container) * on(instance) group_left()
+          (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type)
+          group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t) + sum(container_cpu_allocation{namespace=~\"$namespace\", container=~\"$app.*\"})
+          by (namespace,instance,container) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (container)) [7d:1h]\n\t\t\t\t\t)\n\t\t\t\t\t)"
+        interval: ""
+        legendFormat: Relative price now vs 7d ago (Hour Price)
+        range: true
+        refId: A
+    title: Relative price now vs 7d ago (Hour Price)
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          fixedColor: rgb(31, 120, 193)
+          mode: fixed
+        decimals: 3
+        mappings:
+          - options:
+              match: "null"
+              result:
+                text: N/A
+            type: special
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 6
+      w: 6
+      x: 0
+      "y": 85
+    id: 28
+    interval: ""
+    links: []
+    maxDataPoints: 100
+    options:
+      colorMode: none
+      graphMode: area
+      justifyMode: auto
+      orientation: horizontal
+      reduceOptions:
+        calcs:
+          - mean
+        fields: ""
+        values: false
+      textMode: auto
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "\n  (sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\",
+          container=~\"$app.*\"}) by (container,instance) * on(instance) group_left()
+          (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type)
+          group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\",
+          container=~\"$app.*\"}) by (container,instance) * on(instance) group_left()
+          (\n\t  \t\t\tnode_cpu_hourly_cost{} + on(node,instance_type) group_left()\n\t\t
+          \ \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t  \t\t\t\tkube_node_labels{}, \"instance_type\",
+          \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t  \t\t\t)
+          * 0\n\t\t  \t))) * 24 * 30"
+        instant: true
+        interval: ""
+        legendFormat: ""
+        refId: A
+    timeFrom: 72h
+    title: Live Hour Price
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 6
+      w: 18
+      x: 6
+      "y": 85
+    id: 13
+    interval: ""
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: desc
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\", container=~\"$app.*\"})
+          by (namespace,instance,container) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t) + sum(container_cpu_allocation{namespace=~\"$namespace\", container=~\"$app.*\"})
+          by (namespace,instance,container) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (container)"
+        interval: ""
+        legendFormat: "{{`{{pod}}`}}"
+        range: true
+        refId: A
+    title: APP Pods Hour Price
+    type: timeseries
+  - collapsed: true
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    gridPos:
+      h: 1
+      w: 24
+      x: 0
+      "y": 91
+    id: 31
+    panels:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        fieldConfig:
+          defaults:
+            color:
+              mode: palette-classic
+            custom:
+              axisCenteredZero: false
+              axisColorMode: text
+              axisLabel: ""
+              axisPlacement: auto
+              barAlignment: 0
+              drawStyle: line
+              fillOpacity: 10
+              gradientMode: none
+              hideFrom:
+                legend: false
+                tooltip: false
+                viz: false
+              lineInterpolation: linear
+              lineWidth: 1
+              pointSize: 5
+              scaleDistribution:
+                type: linear
+              showPoints: never
+              spanNulls: false
+              stacking:
+                group: A
+                mode: normal
+              thresholdsStyle:
+                mode: "off"
+            links: []
+            mappings: []
+            thresholds:
+              mode: absolute
+              steps:
+                - color: green
+                - color: red
+                  value: 80
+            unit: currencyUSD
+          overrides: []
+        gridPos:
+          h: 7
+          w: 24
+          x: 0
+          "y": 1
+        id: 33
+        options:
+          legend:
+            calcs:
+              - lastNotNull
+            displayMode: table
+            placement: right
+            showLegend: true
+          tooltip:
+            mode: multi
+            sort: desc
+        pluginVersion: 9.3.1
+        targets:
+          - datasource:
+              type: {{ $defaultDatasource }}
+              uid: "${datasource}"
+            expr: sum(pv_hourly_cost) by (persistentvolume) * 24 * 100
+            interval: ""
+            legendFormat: "{{`{{persistentvolume}}`}}"
+            refId: A
+        title: Kubernetes EBS alocation price by day
+        type: timeseries
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        refId: A
+    title: PVCs (AWS EBS)
+    type: row
+refresh: false
+schemaVersion: 37
+style: dark
+tags: []
+templating:
+  list:
+    - current:
+        selected: false
+        text: Prometheus Datasource
+        value: Prometheus Datasource
+      hide: 0
+      includeAll: false
+      label: Datasource
+      multi: false
+      name: datasource
+      options: []
+      query: prometheus
+      queryValue: ""
+      refresh: 1
+      regex: ""
+      skipUrlSync: false
+      type: datasource
+    - current: {}
+      datasource:
+        type: {{ $defaultDatasource }}
+        uid: "${datasource}"
+      definition: label_values(kube_namespace_labels, namespace)
+      hide: 0
+      includeAll: true
+      label: Namespace
+      multi: true
+      name: namespace
+      options: []
+      query:
+        query: label_values(kube_namespace_labels, namespace)
+        refId: Prometheus Datasource-namespace-Variable-Query
+      refresh: 1
+      regex: ""
+      skipUrlSync: false
+      sort: 0
+      tagValuesQuery: ""
+      tagsQuery: ""
+      type: query
+      useTags: false
+    - current: {}
+      datasource:
+        type: {{ $defaultDatasource }}
+        uid: "${datasource}"
+      definition: label_values(kube_pod_labels{namespace=~"$namespace"}, label_app)
+      hide: 0
+      includeAll: false
+      label: app
+      multi: true
+      name: app
+      options: []
+      query:
+        query: label_values(kube_pod_labels{namespace=~"$namespace"}, label_app)
+        refId: Prometheus Datasource-app-Variable-Query
+      refresh: 1
+      regex: ""
+      skipUrlSync: false
+      sort: 0
+      tagValuesQuery: ""
+      tagsQuery: ""
+      type: query
+      useTags: false
+time:
+  from: now-1h
+  to: now
+timepicker:
+  refresh_intervals:
+    - 5s
+    - 10s
+    - 30s
+    - 1m
+    - 5m
+    - 15m
+    - 30m
+    - 1h
+    - 2h
+    - 1d
+timezone: ""
+title: OpenCost / Cost reporter / Detailed overview
+uid: opencost-cost-reporter-detailed-overview
+version: 30
+weekStart: ""

--- a/charts/motel-mothership/templates/hmc/motel-child/flux-helm.yaml
+++ b/charts/motel-mothership/templates/hmc/motel-child/flux-helm.yaml
@@ -13,5 +13,5 @@ spec:
   sourceRef:
     kind: HelmRepository
     name: motel
-  version: 0.1.1
+  version: 0.1.2
 {{- end }}

--- a/charts/motel-mothership/templates/hmc/motel-child/svctmpl.yaml
+++ b/charts/motel-mothership/templates/hmc/motel-child/svctmpl.yaml
@@ -2,7 +2,7 @@
 apiVersion: hmc.mirantis.com/v1alpha1
 kind: ServiceTemplate
 metadata:
-  name: motel-child-0-1-1
+  name: motel-child-0-1-2
   namespace: hmc-system
 spec:
   helm:
@@ -11,6 +11,6 @@ spec:
       kind: HelmChart
       name: motel-child
       namespace: hmc-system
-    chartVersion: 0.1.1
+    chartVersion: 0.1.2
   providers: []
 {{- end }}

--- a/charts/motel-mothership/templates/hmc/motel-regional/flux-helm.yaml
+++ b/charts/motel-mothership/templates/hmc/motel-regional/flux-helm.yaml
@@ -13,5 +13,5 @@ spec:
   sourceRef:
     kind: HelmRepository
     name: motel
-  version: 0.1.1
+  version: 0.1.2
 {{- end }}

--- a/charts/motel-mothership/templates/hmc/motel-regional/svctmpl.yaml
+++ b/charts/motel-mothership/templates/hmc/motel-regional/svctmpl.yaml
@@ -2,7 +2,7 @@
 apiVersion: hmc.mirantis.com/v1alpha1
 kind: ServiceTemplate
 metadata:
-  name: motel-regional-0-1-1
+  name: motel-regional-0-1-2
   namespace: hmc-system
 spec:
   helm:
@@ -11,6 +11,6 @@ spec:
       kind: HelmChart
       name: motel-regional
       namespace: hmc-system
-    chartVersion: 0.1.1
+    chartVersion: 0.1.2
   providers: []
 {{- end }}

--- a/charts/motel-regional/Chart.lock
+++ b/charts/motel-regional/Chart.lock
@@ -8,5 +8,8 @@ dependencies:
 - name: victoria-logs-single
   repository: https://victoriametrics.github.io/helm-charts/
   version: 0.7.3
-digest: sha256:c4f0c545c2d2cb02102cccfabe709431c5059b4fa8a87cc45aa3327c9a52046e
-generated: "2024-11-19T02:31:29.209783+01:00"
+- name: external-dns
+  repository: https://kubernetes-sigs.github.io/external-dns/
+  version: 1.15.0
+digest: sha256:edf812d433522935fede14109a6ee392ff6c4e9f5ce5f3be4d3887dd8772c2e7
+generated: "2024-12-10T16:23:18.455771+02:00"

--- a/charts/motel-regional/Chart.yaml
+++ b/charts/motel-regional/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: motel-regional
 description: A Helm chart that deploys Grafana, and VictoriaMetrics.
-version: 0.1.1
+version: 0.1.2
 appVersion: "1.0"
 dependencies:
   - name: grafana-operator
@@ -16,3 +16,7 @@ dependencies:
     version: "0.7.*"
     repository: https://victoriametrics.github.io/helm-charts/
     condition: victoria-logs-single.enabled
+  - name: external-dns
+    version: "1.15.0"
+    repository: "https://kubernetes-sigs.github.io/external-dns/"
+    condition: external-dns.enabled

--- a/charts/motel-regional/files/dashboards/opencost-cost-reporter-basic-overview.yaml
+++ b/charts/motel-regional/files/dashboards/opencost-cost-reporter-basic-overview.yaml
@@ -1,0 +1,1464 @@
+{{- $defaultDatasource := "prometheus" -}}
+__inputs:
+  - description: ''
+    label: Prometheus
+    name: DS_PROMETHEUS
+    pluginId: prometheus
+    pluginName: Prometheus
+    type: datasource
+__elements: {}
+__requires:
+  - type: grafana
+    id: grafana
+    name: Grafana
+    version: 10.4.2
+  - type: datasource
+    id: prometheus
+    name: Prometheus
+    version: 1.0.0
+  - type: panel
+    id: stat
+    name: Stat
+    version: ""
+  - type: panel
+    id: table
+    name: Table
+    version: ""
+  - type: panel
+    id: timeseries
+    name: Time series
+    version: ""
+annotations:
+  list:
+    - builtIn: 1
+      datasource:
+        type: grafana
+        uid: "-- Grafana --"
+      enable: true
+      hide: true
+      iconColor: rgba(0, 211, 255, 1)
+      name: Annotations & Alerts
+      type: dashboard
+editable: true
+fiscalYearStartMonth: 0
+graphTooltip: 0
+id:
+links: []
+liveNow: false
+panels:
+  - collapsed: false
+    gridPos:
+      h: 1
+      w: 24
+      x: 0
+      "y": 0
+    id: 2
+    panels: []
+    title: Cluster wide
+    type: row
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: ${datasource}
+    description: Based on the average node_total_hourly_cost in the last 30d
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        decimals: 2
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#299c46"
+              value:
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 6
+      w: 8
+      x: 0
+      "y": 1
+    id: 9
+    options:
+      colorMode: value
+      graphMode: area
+      justifyMode: auto
+      orientation: auto
+      reduceOptions:
+        calcs:
+          - lastNotNull
+        fields: ""
+        values: false
+      showPercentChange: false
+      textMode: auto
+      wideLayout: true
+    pluginVersion: 10.4.2
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: ${datasource}
+        editorMode: code
+        expr: sum(avg by (instance) (node_total_hourly_cost)) * 24
+        instant: false
+        interval: ""
+        legendFormat: __auto
+        range: true
+        refId: A
+    timeFrom: 30d
+    title: Average Daily Cloud Costs
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: ${datasource}
+    description: Based on total node price
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 20
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        mappings: []
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#299c46"
+              value:
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 6
+      w: 16
+      x: 8
+      "y": 1
+    id: 1
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: false
+      tooltip:
+        mode: single
+        sort: none
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr: sum(node_total_hourly_cost)
+        instant: false
+        legendFormat: Cluster Hour Cost
+        range: true
+        refId: A
+    title: Cluster Hour Cost
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: ${datasource}
+    description: Based on the average total hourly node cost from the last 30d
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        decimals: 2
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#299c46"
+              value:
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 6
+      w: 8
+      x: 0
+      "y": 7
+    id: 5
+    options:
+      colorMode: value
+      graphMode: area
+      justifyMode: auto
+      orientation: auto
+      reduceOptions:
+        calcs:
+          - lastNotNull
+        fields: ""
+        values: false
+      showPercentChange: false
+      textMode: auto
+      wideLayout: true
+    pluginVersion: 10.4.2
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr: sum(avg by (instance) (node_total_hourly_cost)) * 24 * 30
+        instant: false
+        interval: ""
+        legendFormat: __auto
+        range: true
+        refId: A
+    timeFrom: 30d
+    title: Estimative Monthly Cloud Costs
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: Based on total node price over 7d and 1d
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 0
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        mappings: []
+        max: 1
+        min: -1
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#299c46"
+              value:
+        unit: percentunit
+      overrides: []
+    gridPos:
+      h: 6
+      w: 8
+      x: 8
+      "y": 7
+    id: 10
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: true
+      tooltip:
+        mode: single
+        sort: none
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr: |-
+          1 - (
+            avg_over_time(
+              sum(node_total_hourly_cost) [1d:1h]
+            )
+          /
+            avg_over_time(
+              sum(node_total_hourly_cost) [7d:1h]
+            )
+          )
+        instant: false
+        legendFormat: Relative price now vs 7d ago (Hour Price)
+        range: true
+        refId: price_7d
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr: |-
+          1 - (
+            avg(sum(node_total_hourly_cost))
+          /
+            avg_over_time(
+              sum(node_total_hourly_cost) [1d:1h]
+            )
+          )
+        hide: false
+        instant: false
+        legendFormat: Relative price now vs 1d ago (Hour Price)
+        range: true
+        refId: price_1d
+    timeFrom: 7d
+    title: Relative price now vs (7/1)d ago (Hour Price)
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: Based on total node price over 7d and 1d
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 0
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        mappings: []
+        max: 1
+        min: -1
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#299c46"
+              value:
+        unit: percentunit
+      overrides: []
+    gridPos:
+      h: 6
+      w: 8
+      x: 16
+      "y": 7
+    id: 11
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: true
+      tooltip:
+        mode: single
+        sort: none
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          stdvar_over_time( sum(node_total_hourly_cost) by (instance_type) [7d:1d]
+          )
+        instant: false
+        legendFormat: Relative price now vs 7d ago (Hour Price)
+        range: true
+        refId: price_variation
+    timeFrom: 7d
+    title: Standard Variation of Cost by InstanceType (7d/1d)
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: ""
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        custom:
+          align: auto
+          cellOptions:
+            type: auto
+          inspect: false
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#73BF69"
+              value:
+        unit: currencyUSD
+      overrides:
+        - matcher:
+            id: byName
+            options: Value
+          properties:
+            - id: custom.cellOptions
+              value:
+                mode: gradient
+                type: gauge
+                valueDisplayMode: text
+    gridPos:
+      h: 22
+      w: 8
+      x: 0
+      "y": 13
+    id: 6
+    options:
+      cellHeight: sm
+      footer:
+        countRows: false
+        fields: ""
+        reducer:
+          - sum
+        show: false
+      showHeader: true
+      sortBy:
+        - desc: true
+          displayName: Cost
+    pluginVersion: 10.4.2
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "topk(20,\n  sum(\n    sum(container_memory_allocation_bytes) \n    by (namespace,instance)\n
+          \   * on(instance) group_left() (\n\t\t\tnode_ram_hourly_cost{} / 1024 / 1024
+          / 1024 * 720\n\t\t\t+ on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n\n    +\n\n    sum(container_cpu_allocation) \n    by (namespace,instance)\n
+          \   * on(instance) group_left() (\n\t\t\tnode_cpu_hourly_cost{} * 720\n\t\t\t+
+          on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n  ) by (namespace)\n)"
+        format: table
+        hide: false
+        instant: true
+        legendFormat: __auto
+        range: false
+        refId: top_namespaces
+    timeFrom: 30d
+    title: Estimated Top 20 Namespaces
+    transformations:
+      - id: organize
+        options:
+          excludeByName:
+            Time: true
+          includeByName: {}
+          indexByName: {}
+          renameByName:
+            Value: Cost
+            namespace: Namespace
+    type: table
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        custom:
+          align: auto
+          cellOptions:
+            type: auto
+          inspect: false
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#73BF69"
+              value:
+        unit: currencyUSD
+      overrides:
+        - matcher:
+            id: byName
+            options: Value
+          properties:
+            - id: custom.cellOptions
+              value:
+                mode: gradient
+                type: gauge
+                valueDisplayMode: text
+    gridPos:
+      h: 22
+      w: 8
+      x: 8
+      "y": 13
+    id: 8
+    options:
+      cellHeight: sm
+      footer:
+        countRows: false
+        fields: ""
+        reducer:
+          - sum
+        show: false
+      showHeader: true
+      sortBy: []
+    pluginVersion: 10.4.2
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "topk(20,\n  sum(\n    sum(container_memory_allocation_bytes) by (namespace,instance,
+          container)\n    * on(instance) group_left() (\n\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024 * 720\n\t\t\t+ on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n    +\n    sum(container_cpu_allocation) by (namespace,instance,
+          container)\n    * on(instance) group_left() (\n\t\t\tnode_cpu_hourly_cost{}
+          * 720\n\t\t\t+ on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n  ) by (namespace, container)\n)"
+        format: table
+        instant: true
+        legendFormat: __auto
+        range: false
+        refId: top_namespaces
+    timeFrom: 30d
+    title: Estimated Top 20 Containers
+    transformations:
+      - id: organize
+        options:
+          excludeByName:
+            Time: true
+          includeByName: {}
+          indexByName:
+            Time: 0
+            Value: 3
+            container: 2
+            namespace: 1
+          renameByName:
+            Value: Cost
+            container: Container
+            namespace: Namespace
+    type: table
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        custom:
+          align: auto
+          cellOptions:
+            type: auto
+          inspect: false
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#73BF69"
+              value:
+        unit: currencyUSD
+      overrides:
+        - matcher:
+            id: byName
+            options: Value
+          properties:
+            - id: custom.cellOptions
+              value:
+                mode: gradient
+                type: gauge
+                valueDisplayMode: text
+    gridPos:
+      h: 22
+      w: 8
+      x: 16
+      "y": 13
+    id: 7
+    options:
+      cellHeight: sm
+      footer:
+        countRows: false
+        fields: ""
+        reducer:
+          - sum
+        show: false
+      showHeader: true
+    pluginVersion: 10.4.2
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "topk(20,\n  sum(\n    sum(container_memory_allocation_bytes) by (namespace,instance,
+          pod)\n    * on(instance) group_left() (\n\t\t\tnode_ram_hourly_cost{} / 1024
+          / 1024 / 1024 * 720\n\t\t\t+ on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n    +\n    sum(container_cpu_allocation) by (namespace,instance,
+          pod)\n    * on(instance) group_left() (\n\t\t\tnode_cpu_hourly_cost{} * 720\n\t\t\t+
+          on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n  ) by (pod)\n)"
+        format: table
+        instant: true
+        legendFormat: __auto
+        range: false
+        refId: top_namespaces
+    timeFrom: 30d
+    title: Estimated Top 20 Pods
+    transformations:
+      - id: organize
+        options:
+          excludeByName:
+            Time: true
+          includeByName: {}
+          indexByName: {}
+          renameByName:
+            Value: Costs
+            namespace: Namespace
+            pod: Pod
+    type: table
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: ""
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        mappings: []
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 12
+      w: 24
+      x: 0
+      "y": 35
+    id: 3
+    options:
+      legend:
+        calcs:
+          - min
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: desc
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "sum(sum(container_memory_allocation_bytes) by (namespace,instance) * on(instance)
+          group_left() (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024 / 1024\n\t\t\t\t+
+          on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation) by (namespace,instance)
+          * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{} + on(node,instance_type)
+          group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t  \t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t
+          \ \t\t\t) * 0\n\t\t  \t)) by (namespace)"
+        instant: false
+        legendFormat: "{{`{{namespace}}`}}"
+        range: true
+        refId: A
+    title: Hour Cost by Namespace
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: ""
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        mappings: []
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 12
+      w: 24
+      x: 0
+      "y": 47
+    id: 4
+    options:
+      legend:
+        calcs:
+          - min
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+        sortBy: Name
+        sortDesc: false
+      tooltip:
+        mode: multi
+        sort: desc
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "sum(sum(container_memory_allocation_bytes) by (container,namespace, instance)
+          * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024
+          / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation) by (container,namespace,
+          instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{} +
+          on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (namespace, container)"
+        instant: false
+        legendFormat: "{{`{{namespace}}`}} / {{`{{container}}`}}"
+        range: true
+        refId: A
+    title: Hour Cost by Container
+    type: timeseries
+  - collapsed: false
+    gridPos:
+      h: 1
+      w: 24
+      x: 0
+      "y": 59
+    id: 12
+    panels: []
+    title: By Namespace $namespace
+    type: row
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        custom:
+          align: auto
+          cellOptions:
+            type: auto
+          inspect: false
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#73BF69"
+              value:
+        unit: currencyUSD
+      overrides:
+        - matcher:
+            id: byName
+            options: Value
+          properties:
+            - id: custom.cellOptions
+              value:
+                mode: gradient
+                type: gauge
+                valueDisplayMode: text
+    gridPos:
+      h: 21
+      w: 5
+      x: 0
+      "y": 60
+    id: 13
+    options:
+      cellHeight: sm
+      footer:
+        countRows: false
+        fields: ""
+        reducer:
+          - sum
+        show: false
+      showHeader: true
+      sortBy: []
+    pluginVersion: 10.4.2
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "topk(20,\n  sum(\n    sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (instance, container)\n    * on(instance) group_left() (\n\t\t\tnode_ram_hourly_cost
+          / 1024 / 1024 / 1024 * 720\n\t\t\t+ on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n    +\n    sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (instance, container)\n    * on(instance) group_left() (\n\t\t\tnode_cpu_hourly_cost{}
+          * 720\n\t\t\t+ on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n  ) by (container)\n)"
+        format: table
+        instant: true
+        legendFormat: __auto
+        range: false
+        refId: top_namespaces
+    timeFrom: 30d
+    title: Estimated Top 20 Containers
+    transformations:
+      - id: organize
+        options:
+          excludeByName:
+            Time: true
+          includeByName: {}
+          indexByName:
+            Time: 0
+            Value: 3
+            container: 2
+            namespace: 1
+          renameByName:
+            Value: Cost
+            container: Container
+            namespace: Namespace
+    type: table
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: Based on current usage
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: text
+              value:
+      overrides: []
+    gridPos:
+      h: 7
+      w: 4
+      x: 5
+      "y": 60
+    id: 14
+    options:
+      colorMode: value
+      graphMode: area
+      justifyMode: auto
+      orientation: auto
+      reduceOptions:
+        calcs:
+          - lastNotNull
+        fields: ""
+        values: false
+      showPercentChange: false
+      textMode: auto
+      wideLayout: true
+    pluginVersion: 10.4.2
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "sum(\n  sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_ram_hourly_cost / 1024
+          / 1024 / 1024\n    + on(node,instance_type) group_left()\n    label_replace\n
+          \   (\n      kube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n    ) * 0\n  )\n  +\n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_cpu_hourly_cost{}\n
+          \   + on(node,instance_type) group_left()\n    label_replace\n    (\n      kube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n
+          \   ) * 0\n  ) \n) * 720"
+        instant: true
+        legendFormat: __auto
+        range: false
+        refId: A
+    title: Estimated monthly costs
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: Based on current usage
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 20
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: text
+              value:
+      overrides: []
+    gridPos:
+      h: 7
+      w: 15
+      x: 9
+      "y": 60
+    id: 17
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: false
+      tooltip:
+        mode: single
+        sort: none
+    pluginVersion: 10.3.3
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "sum(\n  sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_ram_hourly_cost / 1024
+          / 1024 / 1024\n    + on(node,instance_type) group_left()\n    label_replace\n
+          \   (\n      kube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n    ) * 0\n  )\n  +\n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_cpu_hourly_cost{}\n
+          \   + on(node,instance_type) group_left()\n    label_replace\n    (\n      kube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n
+          \   ) * 0\n  ) \n) * 720"
+        instant: false
+        legendFormat: Costs
+        range: true
+        refId: A
+    title: Estimated monthly costs
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: Based on current usage
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: text
+              value:
+      overrides: []
+    gridPos:
+      h: 7
+      w: 4
+      x: 5
+      "y": 67
+    id: 15
+    options:
+      colorMode: value
+      graphMode: area
+      justifyMode: auto
+      orientation: auto
+      reduceOptions:
+        calcs:
+          - lastNotNull
+        fields: ""
+        values: false
+      showPercentChange: false
+      textMode: auto
+      wideLayout: true
+    pluginVersion: 10.4.2
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "sum(\n  sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_ram_hourly_cost / 1024
+          / 1024 / 1024\n    + on(node,instance_type) group_left()\n    label_replace\n
+          \   (\n      kube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n    ) * 0\n  )\n  +\n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_cpu_hourly_cost{}\n
+          \   + on(node,instance_type) group_left()\n    label_replace\n    (\n      kube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n
+          \   ) * 0\n  ) \n) * 24"
+        instant: true
+        legendFormat: __auto
+        range: false
+        refId: A
+    title: Estimated Daily Costs
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: Based on current usage
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 20
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: text
+              value:
+      overrides: []
+    gridPos:
+      h: 7
+      w: 15
+      x: 9
+      "y": 67
+    id: 19
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: false
+      tooltip:
+        mode: single
+        sort: none
+    pluginVersion: 10.3.3
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "sum(\n  sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_ram_hourly_cost / 1024
+          / 1024 / 1024\n    + on(node,instance_type) group_left()\n    label_replace\n
+          \   (\n      kube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n    ) * 0\n  )\n  +\n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_cpu_hourly_cost{}\n
+          \   + on(node,instance_type) group_left()\n    label_replace\n    (\n      kube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n
+          \   ) * 0\n  ) \n) * 24"
+        instant: false
+        legendFormat: Costs
+        range: true
+        refId: A
+    title: Estimated Daily Costs
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: Based on current usage
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: text
+              value:
+      overrides: []
+    gridPos:
+      h: 7
+      w: 4
+      x: 5
+      "y": 74
+    id: 16
+    options:
+      colorMode: value
+      graphMode: area
+      justifyMode: auto
+      orientation: auto
+      reduceOptions:
+        calcs:
+          - lastNotNull
+        fields: ""
+        values: false
+      showPercentChange: false
+      textMode: auto
+      wideLayout: true
+    pluginVersion: 10.4.2
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "sum(\n  sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_ram_hourly_cost / 1024
+          / 1024 / 1024\n    + on(node,instance_type) group_left()\n    label_replace\n
+          \   (\n      kube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n    ) * 0\n  )\n  +\n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_cpu_hourly_cost{}\n
+          \   + on(node,instance_type) group_left()\n    label_replace\n    (\n      kube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n
+          \   ) * 0\n  ) \n)"
+        instant: true
+        legendFormat: __auto
+        range: false
+        refId: A
+    title: Estimated Hourly Costs
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: Based on current usage
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 20
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: text
+              value:
+      overrides: []
+    gridPos:
+      h: 7
+      w: 15
+      x: 9
+      "y": 74
+    id: 18
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: false
+      tooltip:
+        mode: single
+        sort: none
+    pluginVersion: 10.3.3
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "sum(\n  sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_ram_hourly_cost / 1024
+          / 1024 / 1024\n    + on(node,instance_type) group_left()\n    label_replace\n
+          \   (\n      kube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n    ) * 0\n  )\n  +\n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (instance)\n  * on(instance) group_left() (\n    node_cpu_hourly_cost{}\n
+          \   + on(node,instance_type) group_left()\n    label_replace\n    (\n      kube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n
+          \   ) * 0\n  ) \n)"
+        instant: false
+        legendFormat: Costs
+        range: true
+        refId: A
+    title: Estimated Hourly Costs
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    description: ""
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisBorderShow: false
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          insertNulls: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        mappings: []
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 12
+      w: 24
+      x: 0
+      "y": 81
+    id: 20
+    options:
+      legend:
+        calcs:
+          - min
+          - mean
+          - max
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: desc
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        exemplar: false
+        expr:
+          "topk(20,\n  sum(\n    sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (instance, container)\n    * on(instance) group_left() (\n\t\t\tnode_ram_hourly_cost
+          / 1024 / 1024 / 1024 * 720\n\t\t\t+ on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n    +\n    sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (instance, container)\n    * on(instance) group_left() (\n\t\t\tnode_cpu_hourly_cost{}
+          * 720\n\t\t\t+ on(node,instance_type) group_left()\n\t\t\tlabel_replace\n\t\t\t(\n\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t)
+          * 0\n\t\t)\n  ) by (container)\n)"
+        instant: false
+        legendFormat: "{{`{{namespace}}`}}"
+        range: true
+        refId: A
+    title: Hour Price by Namespace
+    type: timeseries
+refresh: ""
+schemaVersion: 39
+tags: []
+templating:
+  list:
+    - current:
+        selected: false
+        text: default
+        value: default
+      hide: 0
+      includeAll: false
+      label: Datasource
+      multi: false
+      name: datasource
+      options: []
+      query: prometheus
+      queryValue: ""
+      refresh: 1
+      regex: ""
+      skipUrlSync: false
+      type: datasource
+    - current: {}
+      datasource:
+        type: {{ $defaultDatasource }}
+        uid: "${datasource}"
+      definition: label_values(kube_namespace_labels,namespace)
+      hide: 0
+      includeAll: false
+      label: Namespace
+      multi: false
+      name: namespace
+      options: []
+      query:
+        qryType: 1
+        query: label_values(kube_namespace_labels,namespace)
+        refId: PrometheusVariableQueryEditor-VariableQuery
+      refresh: 2
+      regex: ""
+      skipUrlSync: false
+      sort: 1
+      type: query
+time:
+  from: now-1h
+  to: now
+timepicker: {}
+timezone: ""
+title: OpenCost / Cost reporter / Basic overview
+uid: opencost-cost-reporter-basic-overview
+version: 52
+weekStart: ""

--- a/charts/motel-regional/files/dashboards/opencost-cost-reporter-detailed-overview.yaml
+++ b/charts/motel-regional/files/dashboards/opencost-cost-reporter-detailed-overview.yaml
@@ -1,0 +1,2160 @@
+{{- $defaultDatasource := "prometheus" -}}
+__inputs:
+  - description: ""
+    label: Prometheus
+    name: DS_PROMETHEUS
+    pluginId: prometheus
+    pluginName: Prometheus
+    type: datasource
+__elements: {}
+__requires:
+  - type: grafana
+    id: grafana
+    name: Grafana
+    version: 9.3.4
+  - type: panel
+    id: graph
+    name: Graph (old)
+    version: ""
+  - type: datasource
+    id: prometheus
+    name: Prometheus
+    version: 1.0.0
+  - type: panel
+    id: stat
+    name: Stat
+    version: ""
+  - type: panel
+    id: table
+    name: Table
+    version: ""
+  - type: panel
+    id: timeseries
+    name: Time series
+    version: ""
+annotations:
+  list:
+    - builtIn: 1
+      datasource:
+        type: datasource
+        uid: grafana
+      enable: true
+      hide: true
+      iconColor: rgba(0, 211, 255, 1)
+      name: Annotations & Alerts
+      target:
+        limit: 100
+        matchAny: false
+        tags: []
+        type: dashboard
+      type: dashboard
+description: ""
+editable: true
+fiscalYearStartMonth: 0
+gnetId: 11270
+graphTooltip: 0
+id:
+links: []
+liveNow: false
+panels:
+  - collapsed: false
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    gridPos:
+      h: 1
+      w: 24
+      x: 0
+      "y": 0
+    id: 9
+    panels: []
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        refId: A
+    title: Cluster Wide
+    type: row
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        decimals: 2
+        mappings:
+          - options:
+              match: "null"
+              result:
+                text: N/A
+            type: special
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#299c46"
+              value:
+            - color: rgba(237, 129, 40, 0.89)
+              value: 1000
+            - color: "#d44a3a"
+              value: 1200
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 7
+      w: 6
+      x: 0
+      "y": 1
+    id: 5
+    links: []
+    maxDataPoints: 100
+    options:
+      colorMode: value
+      graphMode: area
+      justifyMode: auto
+      orientation: horizontal
+      reduceOptions:
+        calcs:
+          - lastNotNull
+        fields: ""
+        values: false
+      textMode: auto
+    pluginVersion: 9.3.4
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        expr: sum(node_total_hourly_cost * 24)
+        hide: false
+        instant: false
+        interval: ""
+        legendFormat: ""
+        refId: A
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        expr: |-
+          avg_over_time(
+            sum(node_total_hourly_cost) [30d:1d]
+          )
+        hide: true
+        interval: ""
+        legendFormat: ""
+        refId: B
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        expr: |-
+          1 - (
+            avg_over_time(
+              sum(node_total_hourly_cost) [1d:1h]
+            )
+          /
+            avg_over_time(
+              sum(node_total_hourly_cost) [7d:1h]
+            )
+          )
+        hide: true
+        interval: ""
+        legendFormat: ""
+        refId: C
+    title: AVG Cluster Cost (last 3 days) DAILY
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 20
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          lineInterpolation: linear
+          lineWidth: 4
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 7
+      w: 18
+      x: 6
+      "y": 1
+    id: 20
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: desc
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        expr: sum(node_total_hourly_cost)
+        hide: false
+        instant: false
+        interval: ""
+        legendFormat: Cluster Hour Cost
+        refId: A
+    timeFrom: 12h
+    title: Cluster Hour Price (last 12h)
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        decimals: 2
+        mappings:
+          - options:
+              match: "null"
+              result:
+                text: N/A
+            type: special
+        thresholds:
+          mode: absolute
+          steps:
+            - color: "#299c46"
+              value:
+            - color: rgba(237, 129, 40, 0.89)
+              value: 27000
+            - color: "#d44a3a"
+              value: 29000
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 8
+      w: 6
+      x: 0
+      "y": 8
+    id: 17
+    links: []
+    maxDataPoints: 100
+    options:
+      colorMode: value
+      graphMode: area
+      justifyMode: auto
+      orientation: horizontal
+      reduceOptions:
+        calcs:
+          - last
+        fields: ""
+        values: false
+      textMode: auto
+    pluginVersion: 9.3.4
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        expr: sum(node_total_hourly_cost * 720)
+        hide: false
+        instant: true
+        interval: ""
+        legendFormat: ""
+        refId: A
+    timeFrom: 720h
+    title: Estimative Cluster Cost (last 30 days based)
+    type: stat
+  - aliasColors: {}
+    bars: false
+    dashLength: 10
+    dashes: false
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fill: 0
+    fillGradient: 0
+    gridPos:
+      h: 8
+      w: 9
+      x: 6
+      "y": 8
+    hiddenSeries: false
+    id: 35
+    legend:
+      avg: false
+      current: false
+      max: false
+      min: false
+      show: true
+      total: false
+      values: false
+    lines: true
+    linewidth: 3
+    nullPointMode: "null"
+    options:
+      alertThreshold: true
+    percentage: false
+    pluginVersion: 9.3.4
+    pointradius: 2
+    points: false
+    renderer: flot
+    seriesOverrides: []
+    spaceLength: 10
+    stack: false
+    steppedLine: false
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        expr: |-
+          1 - (
+            avg_over_time(
+              sum(node_total_hourly_cost) [1d:1h]
+            )
+          /
+            avg_over_time(
+              sum(node_total_hourly_cost) [7d:1h]
+            )
+          )
+        interval: 1h
+        legendFormat: Relative price now vs 7d ago (Hour Price)
+        refId: A
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        expr: |-
+          1 - (
+            avg(sum(node_total_hourly_cost))
+          /
+            avg_over_time(
+              sum(node_total_hourly_cost) [1d:1h]
+            )
+          )
+        hide: false
+        interval: 1h
+        legendFormat: Relative price now vs 1d ago (Hour Price)
+        refId: B
+    thresholds: []
+    timeFrom: 7d
+    timeRegions: []
+    title: Relative price now vs (7/1)d ago (Hour Price)
+    tooltip:
+      shared: true
+      sort: 2
+      value_type: individual
+    type: graph
+    xaxis:
+      mode: time
+      show: true
+      values: []
+    yaxes:
+      - "$$hashKey": object:276
+        format: percentunit
+        logBase: 1
+        max: "1"
+        min: "-1"
+        show: true
+      - "$$hashKey": object:277
+        format: short
+        logBase: 1
+        show: false
+    yaxis:
+      align: false
+  - aliasColors: {}
+    bars: false
+    dashLength: 10
+    dashes: false
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fill: 0
+    fillGradient: 0
+    gridPos:
+      h: 8
+      w: 9
+      x: 15
+      "y": 8
+    hiddenSeries: false
+    id: 38
+    legend:
+      avg: false
+      current: false
+      max: false
+      min: false
+      show: true
+      total: false
+      values: false
+    lines: true
+    linewidth: 3
+    nullPointMode: "null"
+    options:
+      alertThreshold: true
+    percentage: false
+    pluginVersion: 9.3.4
+    pointradius: 2
+    points: false
+    renderer: flot
+    seriesOverrides: []
+    spaceLength: 10
+    stack: false
+    steppedLine: false
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        expr:
+          stdvar_over_time( sum(node_total_hourly_cost) by (instance_type) [7d:1d]
+          ) > 0
+        instant: false
+        interval: 1h
+        legendFormat: "{{ `{{instance_type }}` }}"
+        refId: A
+    thresholds: []
+    timeFrom: 7d
+    timeRegions: []
+    title: Standard Variation of Cost by InstanceType (7d/1d)
+    tooltip:
+      shared: true
+      sort: 2
+      value_type: individual
+    type: graph
+    xaxis:
+      mode: time
+      show: true
+      values: []
+    yaxes:
+      - "$$hashKey": object:103
+        format: currencyUSD
+        logBase: 1
+        show: true
+      - "$$hashKey": object:104
+        format: short
+        logBase: 1
+        show: false
+    yaxis:
+      align: false
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        custom:
+          align: auto
+          displayMode: auto
+          inspect: false
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides:
+        - matcher:
+            id: byName
+            options: Time
+          properties:
+            - id: custom.hidden
+              value: true
+        - matcher:
+            id: byName
+            options: namespace
+          properties:
+            - id: custom.width
+              value: 135
+        - matcher:
+            id: byName
+            options: Value
+          properties:
+            - id: custom.align
+              value: left
+    gridPos:
+      h: 23
+      w: 3
+      x: 0
+      "y": 16
+    id: 6
+    options:
+      footer:
+        fields: ""
+        reducer:
+          - sum
+        show: false
+      showHeader: true
+      sortBy:
+        - desc: true
+          displayName: Value
+    pluginVersion: 9.3.4
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "topk( 20, \n  sum(sum(container_memory_allocation_bytes) by (namespace,instance)
+          * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024
+          / 1024 * 730\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation) by (namespace,instance)
+          * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{} + on(node,instance_type)
+          group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t  \t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t
+          \ \t\t\t) * 0\n\t\t  \t) * 730) by (namespace)\n)"
+        format: table
+        instant: true
+        interval: ""
+        legendFormat: "{{`{{namespace}}`}}"
+        refId: A
+    title: Top 20 by Namespace
+    transformations: []
+    type: table
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        custom:
+          align: auto
+          displayMode: auto
+          inspect: false
+        decimals: 2
+        displayName: ""
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+            - color: red
+              value: 80
+        unit: short
+      overrides:
+        - matcher:
+            id: byName
+            options: Time
+          properties:
+            - id: displayName
+              value: Time
+            - id: custom.align
+            - id: custom.hidden
+              value: true
+        - matcher:
+            id: byName
+            options: Metric
+          properties:
+            - id: displayName
+              value: Container Name
+            - id: unit
+              value: short
+            - id: decimals
+              value: 2
+            - id: custom.align
+        - matcher:
+            id: byName
+            options: Value
+          properties:
+            - id: displayName
+              value: "Price "
+            - id: unit
+              value: currencyUSD
+            - id: decimals
+              value: 2
+            - id: custom.align
+        - matcher:
+            id: byName
+            options: Container Name
+          properties:
+            - id: custom.width
+              value: 124
+    gridPos:
+      h: 23
+      w: 4
+      x: 3
+      "y": 16
+    id: 2
+    options:
+      footer:
+        fields: ""
+        reducer:
+          - sum
+        show: false
+      showHeader: true
+      sortBy: []
+    pluginVersion: 9.3.4
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "topk( 20, \n  sum(sum(container_memory_allocation_bytes) by (container,instance)
+          * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024
+          / 1024 * 730\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation) by (container,instance)
+          * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{} + on(node,instance_type)
+          group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t  \t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t
+          \ \t\t\t) * 0\n\t\t  \t)) by (container)\n)"
+        instant: true
+        interval: ""
+        legendFormat: "{{`{{container}}`}}"
+        refId: A
+    title: Estimated Top 20 by Container (30 days)
+    transformations:
+      - id: seriesToRows
+        options:
+          reducers: []
+    type: table
+  - aliasColors: {}
+    bars: false
+    dashLength: 10
+    dashes: false
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        links: []
+      overrides: []
+    fill: 1
+    fillGradient: 0
+    gridPos:
+      h: 11
+      w: 17
+      x: 7
+      "y": 16
+    hiddenSeries: false
+    id: 15
+    legend:
+      avg: false
+      current: false
+      max: false
+      min: false
+      show: true
+      total: false
+      values: false
+    lines: true
+    linewidth: 1
+    nullPointMode: "null"
+    options:
+      alertThreshold: true
+    percentage: false
+    pluginVersion: 9.3.4
+    pointradius: 2
+    points: false
+    renderer: flot
+    seriesOverrides: []
+    spaceLength: 10
+    stack: false
+    steppedLine: false
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        expr:
+          "sum(sum(container_memory_allocation_bytes) by (namespace,instance) * on(instance)
+          group_left() (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024 / 1024\n\t\t\t\t+
+          on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation) by (namespace,instance)
+          * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{} + on(node,instance_type)
+          group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t  \t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t
+          \ \t\t\t) * 0\n\t\t  \t)) by (namespace)"
+        interval: ""
+        legendFormat: "{{`{{namespace}}`}}"
+        refId: A
+    thresholds: []
+    timeRegions: []
+    title: Hour Cost
+    tooltip:
+      shared: true
+      sort: 2
+      value_type: individual
+    type: graph
+    xaxis:
+      mode: time
+      show: true
+      values: []
+    yaxes:
+      - format: currencyUSD
+        logBase: 1
+        show: true
+      - format: short
+        logBase: 1
+        show: true
+    yaxis:
+      align: false
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: continuous-GrYlRd
+        custom:
+          axisCenteredZero: false
+          axisColorMode: series
+          axisGridShow: true
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 12
+      w: 17
+      x: 7
+      "y": 27
+    id: 16
+    options:
+      legend:
+        calcs:
+          - mean
+        displayMode: table
+        placement: right
+        showLegend: true
+        sortBy: Mean
+        sortDesc: true
+      timezone:
+        - browser
+      tooltip:
+        mode: multi
+        sort: desc
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "sum(sum(container_memory_allocation_bytes) by (container,namespace, instance)
+          * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024
+          / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation) by (container,namespace,
+          instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{} +
+          on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (namespace, container)"
+        interval: ""
+        legendFormat: "{{`{{namespace}}`}} / {{`{{container}}`}}"
+        range: true
+        refId: A
+    title: Hour Price by Container
+    type: timeseries
+  - collapsed: false
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    gridPos:
+      h: 1
+      w: 24
+      x: 0
+      "y": 39
+    id: 11
+    panels: []
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        refId: A
+    title: By Namespace $namespace
+    type: row
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: thresholds
+        custom:
+          align: auto
+          displayMode: auto
+          inspect: false
+        decimals: 2
+        displayName: ""
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+            - color: red
+              value: 80
+        unit: short
+      overrides:
+        - matcher:
+            id: byName
+            options: Time
+          properties:
+            - id: displayName
+              value: Time
+            - id: custom.align
+            - id: custom.hidden
+              value: true
+        - matcher:
+            id: byName
+            options: Metric
+          properties:
+            - id: displayName
+              value: Container Name
+            - id: unit
+              value: short
+            - id: decimals
+              value: 2
+            - id: custom.align
+        - matcher:
+            id: byName
+            options: Value
+          properties:
+            - id: displayName
+              value: "Price "
+            - id: unit
+              value: currencyUSD
+            - id: decimals
+              value: 2
+            - id: custom.align
+              value: left
+    gridPos:
+      h: 21
+      w: 4
+      x: 0
+      "y": 40
+    id: 12
+    options:
+      footer:
+        fields: ""
+        reducer:
+          - sum
+        show: false
+      showHeader: true
+    pluginVersion: 9.3.4
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "topk( 20, \n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (container, instance, namespace) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (container, instance, namespace) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (container)\n)"
+        format: time_series
+        instant: true
+        interval: ""
+        legendFormat: "{{`{{container}}`}}"
+        refId: A
+    title: Top 20 by Container
+    transformations:
+      - id: seriesToRows
+        options:
+          reducers: []
+    type: table
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          fixedColor: rgb(31, 120, 193)
+          mode: fixed
+        decimals: 3
+        mappings:
+          - options:
+              match: "null"
+              result:
+                text: N/A
+            type: special
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 7
+      w: 4
+      x: 4
+      "y": 40
+    id: 23
+    interval: ""
+    links: []
+    maxDataPoints: 100
+    options:
+      colorMode: none
+      graphMode: area
+      justifyMode: auto
+      orientation: horizontal
+      reduceOptions:
+        calcs:
+          - mean
+        fields: "/^Month estimative$/"
+        values: false
+      textMode: auto
+    pluginVersion: 9.3.4
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "\n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) * 720"
+        instant: true
+        interval: ""
+        legendFormat: Month estimative
+        refId: A
+    title: Live Month Price
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        decimals: 3
+        links: []
+        mappings: []
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 7
+      w: 16
+      x: 8
+      "y": 40
+    id: 24
+    links: []
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: none
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "\n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) * 720"
+        instant: false
+        interval: ""
+        legendFormat: Month estimative
+        refId: A
+    title: Month Estimative avg
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          fixedColor: rgb(31, 120, 193)
+          mode: fixed
+        decimals: 3
+        mappings:
+          - options:
+              match: "null"
+              result:
+                text: N/A
+            type: special
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 7
+      w: 4
+      x: 4
+      "y": 47
+    id: 22
+    interval: ""
+    links: []
+    maxDataPoints: 100
+    options:
+      colorMode: none
+      graphMode: area
+      justifyMode: auto
+      orientation: horizontal
+      reduceOptions:
+        calcs:
+          - mean
+        fields: ""
+        values: false
+      textMode: auto
+    pluginVersion: 9.3.4
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "\n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) * 24 * 7"
+        instant: true
+        interval: ""
+        legendFormat: ""
+        refId: A
+    timeFrom: 72h
+    title: Live Day Price
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        min: 0
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+              value:
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 7
+      w: 16
+      x: 8
+      "y": 47
+    id: 36
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: desc
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "topk( 20, \n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (namespace,container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (namespace,container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (namespace)\n)"
+        interval: ""
+        legendFormat: "{{`{{namespace}}`}}"
+        range: true
+        refId: A
+    title: Namespace Hour Price
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          fixedColor: rgb(31, 120, 193)
+          mode: fixed
+        decimals: 3
+        mappings:
+          - options:
+              match: "null"
+              result:
+                text: N/A
+            type: special
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 7
+      w: 4
+      x: 4
+      "y": 54
+    id: 25
+    interval: ""
+    links: []
+    maxDataPoints: 100
+    options:
+      colorMode: none
+      graphMode: area
+      justifyMode: auto
+      orientation: horizontal
+      reduceOptions:
+        calcs:
+          - mean
+        fields: ""
+        values: false
+      textMode: auto
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "\n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t))"
+        instant: true
+        interval: ""
+        legendFormat: ""
+        refId: A
+    timeFrom: 72h
+    title: Live Hour Price
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        max: 1
+        min: -1
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+            - color: red
+              value: 80
+        unit: percentunit
+      overrides:
+        - matcher:
+            id: byName
+            options: Relative price now vs 14d ago (Hour Price)
+          properties:
+            - id: color
+              value:
+                fixedColor: purple
+                mode: fixed
+        - matcher:
+            id: byName
+            options: Relative price now vs 7d ago (Hour Price)
+          properties:
+            - id: color
+              value:
+                fixedColor: blue
+                mode: fixed
+    gridPos:
+      h: 7
+      w: 16
+      x: 8
+      "y": 54
+    id: 14
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: desc
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "1 - (\n\navg_over_time(\n\n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (namespace, container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (namespace,container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (namespace) [1d:1h]\n            )\n
+          \           \n            /\n            \navg_over_time(\n\n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (namespace,container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (namespace,container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (namespace) [7d:1h]\n            )\n
+          \           )"
+        interval: ""
+        legendFormat: Relative price now vs 7d ago (Hour Price)
+        range: true
+        refId: A
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "1 - (\n\navg_over_time(\n\n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (namespace,container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (namespace,container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (namespace) [1d:1h]\n            )\n
+          \           \n            /\n            \navg_over_time(\n\n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (namespace,container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (namespace,container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (namespace) [14d:1h]\n            )\n
+          \           )"
+        interval: ""
+        legendFormat: Relative price now vs 14d ago (Hour Price)
+        range: true
+        refId: B
+    title: Relative price now vs (7/14)d ago (Hour Price)
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 11
+      w: 24
+      x: 0
+      "y": 61
+    id: 4
+    options:
+      legend:
+        calcs:
+          - mean
+          - max
+          - min
+        displayMode: table
+        placement: right
+        showLegend: true
+        sortBy: Mean
+        sortDesc: true
+      tooltip:
+        mode: multi
+        sort: desc
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "topk( 30, \n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\"})
+          by (container,instance) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (container)\n)"
+        interval: ""
+        legendFormat: "{{`{{container}}`}}"
+        range: true
+        refId: A
+    title: Hour Price by App
+    type: timeseries
+  - collapsed: false
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    gridPos:
+      h: 1
+      w: 24
+      x: 0
+      "y": 72
+    id: 19
+    panels: []
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        refId: A
+    title: App $app by pod
+    type: row
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          fixedColor: rgb(31, 120, 193)
+          mode: fixed
+        decimals: 3
+        mappings:
+          - options:
+              match: "null"
+              result:
+                text: N/A
+            type: special
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 6
+      w: 6
+      x: 0
+      "y": 73
+    id: 26
+    interval: ""
+    links: []
+    maxDataPoints: 100
+    options:
+      colorMode: none
+      graphMode: area
+      justifyMode: auto
+      orientation: horizontal
+      reduceOptions:
+        calcs:
+          - mean
+        fields: ""
+        values: false
+      textMode: auto
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "\n  sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\",
+          container=~\"$app.*\"}) by (container,instance) * on(instance) group_left()
+          (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type)
+          group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\",
+          container=~\"$app.*\"}) by (container,instance) * on(instance) group_left()
+          (\n\t  \t\t\tnode_cpu_hourly_cost{} + on(node,instance_type) group_left()\n\t\t
+          \ \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t  \t\t\t\tkube_node_labels{}, \"instance_type\",
+          \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t  \t\t\t)
+          * 0\n\t\t  \t))"
+        instant: true
+        interval: ""
+        legendFormat: ""
+        refId: A
+    timeFrom: 72h
+    title: Live Hour Price
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 6
+      w: 18
+      x: 6
+      "y": 73
+    id: 29
+    interval: ""
+    options:
+      legend:
+        calcs:
+          - mean
+          - lastNotNull
+          - max
+          - min
+        displayMode: table
+        placement: right
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: desc
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "sum(sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\",
+          container=~\"$app.*\"}) by (namespace,instance,container) * on(instance) group_left()
+          (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type)
+          group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t) + sum(container_cpu_allocation{namespace=~\"$namespace\", container=~\"$app.*\"})
+          by (namespace,instance,container) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (container))"
+        interval: ""
+        legendFormat: Hour Cost
+        range: true
+        refId: A
+    title: APP  Hour Price
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          fixedColor: rgb(31, 120, 193)
+          mode: fixed
+        decimals: 3
+        mappings:
+          - options:
+              match: "null"
+              result:
+                text: N/A
+            type: special
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 6
+      w: 6
+      x: 0
+      "y": 79
+    id: 27
+    interval: ""
+    links: []
+    maxDataPoints: 100
+    options:
+      colorMode: none
+      graphMode: area
+      justifyMode: auto
+      orientation: horizontal
+      reduceOptions:
+        calcs:
+          - mean
+        fields: ""
+        values: false
+      textMode: auto
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "\n  (sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\",
+          container=~\"$app.*\"}) by (container,instance) * on(instance) group_left()
+          (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type)
+          group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\",
+          container=~\"$app.*\"}) by (container,instance) * on(instance) group_left()
+          (\n\t  \t\t\tnode_cpu_hourly_cost{} + on(node,instance_type) group_left()\n\t\t
+          \ \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t  \t\t\t\tkube_node_labels{}, \"instance_type\",
+          \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t  \t\t\t)
+          * 0\n\t\t  \t))) * 24"
+        instant: true
+        interval: ""
+        legendFormat: ""
+        refId: A
+    timeFrom: 72h
+    title: Live Hour Price
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        max: 1
+        min: -1
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+            - color: red
+              value: 80
+        unit: percentunit
+      overrides:
+        - matcher:
+            id: byName
+            options: Relative price now vs 7d ago (Hour Price)
+          properties:
+            - id: color
+              value:
+                fixedColor: blue
+                mode: fixed
+    gridPos:
+      h: 6
+      w: 18
+      x: 6
+      "y": 79
+    id: 37
+    interval: ""
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: desc
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "1 - (\n\navg_over_time(\nsum(sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\",
+          container=~\"$app.*\"}) by (namespace,instance,container) * on(instance) group_left()
+          (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type)
+          group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t) + sum(container_cpu_allocation{namespace=~\"$namespace\", container=~\"$app.*\"})
+          by (namespace,instance,container) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (container)) [1d:1h]\n\t\t\t\t\t)\n/\n\navg_over_time(\nsum(sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\",
+          container=~\"$app.*\"}) by (namespace,instance,container) * on(instance) group_left()
+          (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type)
+          group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t) + sum(container_cpu_allocation{namespace=~\"$namespace\", container=~\"$app.*\"})
+          by (namespace,instance,container) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (container)) [7d:1h]\n\t\t\t\t\t)\n\t\t\t\t\t)"
+        interval: ""
+        legendFormat: Relative price now vs 7d ago (Hour Price)
+        range: true
+        refId: A
+    title: Relative price now vs 7d ago (Hour Price)
+    type: timeseries
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          fixedColor: rgb(31, 120, 193)
+          mode: fixed
+        decimals: 3
+        mappings:
+          - options:
+              match: "null"
+              result:
+                text: N/A
+            type: special
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 6
+      w: 6
+      x: 0
+      "y": 85
+    id: 28
+    interval: ""
+    links: []
+    maxDataPoints: 100
+    options:
+      colorMode: none
+      graphMode: area
+      justifyMode: auto
+      orientation: horizontal
+      reduceOptions:
+        calcs:
+          - mean
+        fields: ""
+        values: false
+      textMode: auto
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "\n  (sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\",
+          container=~\"$app.*\"}) by (container,instance) * on(instance) group_left()
+          (\n\t\t\t\tnode_ram_hourly_cost{} / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type)
+          group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t)\n  + \n  sum(container_cpu_allocation{namespace=~\"$namespace\",
+          container=~\"$app.*\"}) by (container,instance) * on(instance) group_left()
+          (\n\t  \t\t\tnode_cpu_hourly_cost{} + on(node,instance_type) group_left()\n\t\t
+          \ \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t  \t\t\t\tkube_node_labels{}, \"instance_type\",
+          \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t  \t\t\t)
+          * 0\n\t\t  \t))) * 24 * 30"
+        instant: true
+        interval: ""
+        legendFormat: ""
+        refId: A
+    timeFrom: 72h
+    title: Live Hour Price
+    type: stat
+  - datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    fieldConfig:
+      defaults:
+        color:
+          mode: palette-classic
+        custom:
+          axisCenteredZero: false
+          axisColorMode: text
+          axisLabel: ""
+          axisPlacement: auto
+          barAlignment: 0
+          drawStyle: line
+          fillOpacity: 10
+          gradientMode: none
+          hideFrom:
+            legend: false
+            tooltip: false
+            viz: false
+          lineInterpolation: linear
+          lineWidth: 1
+          pointSize: 5
+          scaleDistribution:
+            type: linear
+          showPoints: never
+          spanNulls: false
+          stacking:
+            group: A
+            mode: none
+          thresholdsStyle:
+            mode: "off"
+        links: []
+        mappings: []
+        thresholds:
+          mode: absolute
+          steps:
+            - color: green
+            - color: red
+              value: 80
+        unit: currencyUSD
+      overrides: []
+    gridPos:
+      h: 6
+      w: 18
+      x: 6
+      "y": 85
+    id: 13
+    interval: ""
+    options:
+      legend:
+        calcs: []
+        displayMode: list
+        placement: bottom
+        showLegend: true
+      tooltip:
+        mode: multi
+        sort: desc
+    pluginVersion: 9.3.1
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        editorMode: code
+        expr:
+          "sum(sum(container_memory_allocation_bytes{namespace=~\"$namespace\", container=~\"$app.*\"})
+          by (namespace,instance,container) * on(instance) group_left() (\n\t\t\t\tnode_ram_hourly_cost{}
+          / 1024 / 1024 / 1024\n\t\t\t\t+ on(node,instance_type) group_left()\n\t\t\t\t\tlabel_replace\n\t\t\t\t\t(\n\t\t\t\t\t\tkube_node_labels{},
+          \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\", \"(.*)\"\n\t\t\t\t\t)
+          * 0\n\t\t\t) + sum(container_cpu_allocation{namespace=~\"$namespace\", container=~\"$app.*\"})
+          by (namespace,instance,container) * on(instance) group_left() (\n\t  \t\t\tnode_cpu_hourly_cost{}
+          + on(node,instance_type) group_left()\n\t\t  \t\t\tlabel_replace\n\t\t  \t\t\t(\n\t\t
+          \ \t\t\t\tkube_node_labels{}, \"instance_type\", \"$1\", \"label_node_kubernetes_io_instance_type\",
+          \"(.*)\"\n\t\t  \t\t\t) * 0\n\t\t  \t)) by (container)"
+        interval: ""
+        legendFormat: "{{`{{pod}}`}}"
+        range: true
+        refId: A
+    title: APP Pods Hour Price
+    type: timeseries
+  - collapsed: true
+    datasource:
+      type: {{ $defaultDatasource }}
+      uid: "${datasource}"
+    gridPos:
+      h: 1
+      w: 24
+      x: 0
+      "y": 91
+    id: 31
+    panels:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        fieldConfig:
+          defaults:
+            color:
+              mode: palette-classic
+            custom:
+              axisCenteredZero: false
+              axisColorMode: text
+              axisLabel: ""
+              axisPlacement: auto
+              barAlignment: 0
+              drawStyle: line
+              fillOpacity: 10
+              gradientMode: none
+              hideFrom:
+                legend: false
+                tooltip: false
+                viz: false
+              lineInterpolation: linear
+              lineWidth: 1
+              pointSize: 5
+              scaleDistribution:
+                type: linear
+              showPoints: never
+              spanNulls: false
+              stacking:
+                group: A
+                mode: normal
+              thresholdsStyle:
+                mode: "off"
+            links: []
+            mappings: []
+            thresholds:
+              mode: absolute
+              steps:
+                - color: green
+                - color: red
+                  value: 80
+            unit: currencyUSD
+          overrides: []
+        gridPos:
+          h: 7
+          w: 24
+          x: 0
+          "y": 1
+        id: 33
+        options:
+          legend:
+            calcs:
+              - lastNotNull
+            displayMode: table
+            placement: right
+            showLegend: true
+          tooltip:
+            mode: multi
+            sort: desc
+        pluginVersion: 9.3.1
+        targets:
+          - datasource:
+              type: {{ $defaultDatasource }}
+              uid: "${datasource}"
+            expr: sum(pv_hourly_cost) by (persistentvolume) * 24 * 100
+            interval: ""
+            legendFormat: "{{`{{persistentvolume}}`}}"
+            refId: A
+        title: Kubernetes EBS alocation price by day
+        type: timeseries
+    targets:
+      - datasource:
+          type: {{ $defaultDatasource }}
+          uid: "${datasource}"
+        refId: A
+    title: PVCs (AWS EBS)
+    type: row
+refresh: false
+schemaVersion: 37
+style: dark
+tags: []
+templating:
+  list:
+    - current:
+        selected: false
+        text: Prometheus Datasource
+        value: Prometheus Datasource
+      hide: 0
+      includeAll: false
+      label: Datasource
+      multi: false
+      name: datasource
+      options: []
+      query: prometheus
+      queryValue: ""
+      refresh: 1
+      regex: ""
+      skipUrlSync: false
+      type: datasource
+    - current: {}
+      datasource:
+        type: {{ $defaultDatasource }}
+        uid: "${datasource}"
+      definition: label_values(kube_namespace_labels, namespace)
+      hide: 0
+      includeAll: true
+      label: Namespace
+      multi: true
+      name: namespace
+      options: []
+      query:
+        query: label_values(kube_namespace_labels, namespace)
+        refId: Prometheus Datasource-namespace-Variable-Query
+      refresh: 1
+      regex: ""
+      skipUrlSync: false
+      sort: 0
+      tagValuesQuery: ""
+      tagsQuery: ""
+      type: query
+      useTags: false
+    - current: {}
+      datasource:
+        type: {{ $defaultDatasource }}
+        uid: "${datasource}"
+      definition: label_values(kube_pod_labels{namespace=~"$namespace"}, label_app)
+      hide: 0
+      includeAll: false
+      label: app
+      multi: true
+      name: app
+      options: []
+      query:
+        query: label_values(kube_pod_labels{namespace=~"$namespace"}, label_app)
+        refId: Prometheus Datasource-app-Variable-Query
+      refresh: 1
+      regex: ""
+      skipUrlSync: false
+      sort: 0
+      tagValuesQuery: ""
+      tagsQuery: ""
+      type: query
+      useTags: false
+time:
+  from: now-1h
+  to: now
+timepicker:
+  refresh_intervals:
+    - 5s
+    - 10s
+    - 30s
+    - 1m
+    - 5m
+    - 15m
+    - 30m
+    - 1h
+    - 2h
+    - 1d
+timezone: ""
+title: OpenCost / Cost reporter / Detailed overview
+uid: opencost-cost-reporter-detailed-overview
+version: 30
+weekStart: ""

--- a/charts/motel-regional/values.yaml
+++ b/charts/motel-regional/values.yaml
@@ -5,6 +5,21 @@ global:
 cert-manager:
   enabled: true
   email: mail@example.net
+external-dns:
+  enabled: false
+  provider:
+    name: aws
+  env:
+    - name: AWS_SHARED_CREDENTIALS_FILE
+      value: /etc/aws/credentials/credentials
+  extraVolumeMounts:
+    - name: aws-credentials
+      mountPath: /etc/aws/credentials
+      readOnly: true
+  extraVolumes:
+    - name: aws-credentials
+      secret:
+        secretName: external-dns-aws-credentials
 victoriametrics:
   enabled: true
   vmauth:
@@ -43,3 +58,4 @@ victoria-logs-single:
       storageClassName: ebs-csi-default-sc
   fluent-bit:
     enabled: false
+

--- a/demo/cluster/aws-child.yaml
+++ b/demo/cluster/aws-child.yaml
@@ -22,10 +22,16 @@ spec:
   template: aws-standalone-cp-0-0-3
   servicesPriority: 100
   services:
-    - template: motel-child-0-1-1
+    - template: motel-child-0-1-2
       name: motel-child
       namespace: motel-child
       values: |
+        opencost:
+          prometheus:
+            external:
+              url: "https://vmauth.hmc0.example.net/vm/select/0/prometheus"
+          exporter:
+            defaultClusterId: "aws-child0"
         victoriametrics:
           vmagent:
             remoteWriteUrl: https://vmauth.hmc0.example.net/vm/insert/0/prometheus/api/v1/write

--- a/demo/cluster/aws-regional.yaml
+++ b/demo/cluster/aws-regional.yaml
@@ -33,7 +33,7 @@ spec:
           enabled: true
     - name: motel-regional
       namespace: motel
-      template: motel-regional-0-1-1
+      template: motel-regional-0-1-2
       values: |
         victoriametrics:
           vmauth:


### PR DESCRIPTION
Optional availability to enable [external-dns](https://kubernetes-sigs.github.io/external-dns/) service to automatically manage ingress hostnames.

Close https://github.com/Mirantis/motel/issues/7

Close https://github.com/Mirantis/hmc/issues/735